### PR TITLE
hm: value-level hashcons state to avoid functors

### DIFF
--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -8,16 +8,17 @@ open Unification
 open Inference
 open Solve_bv
 
-let retype_var univ ctx id =
-  lookup_var_typ ~no_constraint:true univ ctx id |> find |> to_basil
+let retype_var st univ ctx id =
+  lookup_var_typ st ~no_constraint:true univ ctx id
+  |> TypeExpr.find st |> to_basil
   |> fun typ -> Var.copy ~typ id
 
-let elaborate_phi univ ctx (p : Var.t Block.phi list) =
+let elaborate_phi st univ ctx (p : Var.t Block.phi list) =
   let open Block in
   List.map
     (fun { lhs; rhs } ->
-      let lhs = retype_var univ ctx lhs in
-      let rhs = List.map (fun (a, r) -> (a, retype_var univ ctx r)) rhs in
+      let lhs = retype_var st univ ctx lhs in
+      let rhs = List.map (fun (a, r) -> (a, retype_var st univ ctx r)) rhs in
       { lhs; rhs })
     p
 
@@ -26,62 +27,57 @@ let ctx_to_string ctx =
   |> Iter.to_string (fun (a, b) ->
       Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
 
-let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
 let unfix i = match i with Expr.BasilExpr.E i -> i
 let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
 
 (** Extract type after full inference has run. *)
-let elaborate_expr ~univ (hr : Lexing.position) e (c : scheme TypeExpr.TCtx.t) =
+let elaborate_expr st ~univ (hr : Lexing.position) e
+    (c : scheme TypeExpr.TCtx.t) =
   let alg e =
     let e =
       match e with
       | AbstractExpr.RVar { id; attrib; typ } ->
           (* avoid looking up the id in context as we may be in a local
             binding *)
-          let id = Var.copy id ~typ:(to_basil @@ find typ) in
+          let id = Var.copy id ~typ:(to_basil @@ TypeExpr.find st typ) in
           AbstractExpr.RVar { id; attrib; typ }
       | o -> o
     in
-    let t = AbstractExpr.get_typ e |> find |> to_basil in
+    let t = AbstractExpr.get_typ e |> TypeExpr.find st |> to_basil in
     AbstractExpr.set_typ e t |> Expr.BasilExpr.fix
   in
   e |> TypingExpr.cata alg
 
-let elaborate_stmt univ ctx stmt =
-  let retype_var v =
-    let typ =
-      lookup_var_typ ~no_constraint:true univ ctx v |> find |> to_basil
-    in
-    Var.copy ~typ v
-  in
+let elaborate_stmt st univ ctx stmt =
+  let retype_var = retype_var st univ ctx in
   Stmt.map
-    ~f_expr:(fun e -> elaborate_expr ~univ [%here] e ctx)
+    ~f_expr:(fun e -> elaborate_expr st ~univ [%here] e ctx)
     ~f_lvar:retype_var ~f_rvar:retype_var stmt
 
-let elaborate_block p univ ctx (b : ('a, 'b) Block.t) =
-  Block.map ~phi:(elaborate_phi univ ctx) (elaborate_stmt univ ctx) b
+let elaborate_block st p univ ctx (b : ('a, 'b) Block.t) =
+  Block.map ~phi:(elaborate_phi st univ ctx) (elaborate_stmt st univ ctx) b
 
-let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
+let assume_proc_decl st ctx ?(no_constraint = false) (p : Program.proc) =
   let globs = Var.Decls.values (Procedure.local_decls p) in
   let formals_in = Procedure.formal_in_params p |> StringMap.values in
   let formals_out = Procedure.formal_out_params p |> StringMap.values in
   let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
   let ctx =
     Iter.fold
-      (decl_var_typ ~no_constraint univ)
+      (decl_var_typ st ~no_constraint univ)
       ctx
       (Iter.append globs @@ Iter.append formals_in formals_out)
   in
   ctx
 
-let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
+let infer_proc st vc prog ctx ?(no_constraint = false) (p : Program.proc) =
   let spec = Procedure.specification p in
   let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
   let ibool_list b =
     List.map
       (fun a ->
-        let a = infer_expr vc ~univ [%here] a ctx in
-        let _ = unify bool_type (getty a) in
+        let a = infer_expr st vc ~univ [%here] a ctx in
+        let _ = unify st (bool_type st) (getty a) in
         a)
       b
   in
@@ -92,30 +88,30 @@ let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
       rely = ibool_list spec.rely;
       guarantee = ibool_list spec.guarantee;
       captures_globs =
-        List.map (infer_var global_universe ctx) spec.captures_globs;
+        List.map (infer_var st global_universe ctx) spec.captures_globs;
       modifies_globs =
-        List.map (infer_var global_universe ctx) spec.modifies_globs;
+        List.map (infer_var st global_universe ctx) spec.modifies_globs;
     }
   in
 
   let new_spec ctx : (Var.t, Expr.BasilExpr.t) Procedure.proc_spec =
     {
       requires =
-        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.requires;
+        List.map (fun e -> elaborate_expr st ~univ [%here] e ctx) spec.requires;
       ensures =
-        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.ensures;
-      rely = List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.rely;
+        List.map (fun e -> elaborate_expr st ~univ [%here] e ctx) spec.ensures;
+      rely = List.map (fun e -> elaborate_expr st ~univ [%here] e ctx) spec.rely;
       guarantee =
-        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.guarantee;
+        List.map (fun e -> elaborate_expr st ~univ [%here] e ctx) spec.guarantee;
       captures_globs = spec.captures_globs |> List.map fst;
       modifies_globs = spec.modifies_globs |> List.map fst;
     }
   in
 
-  let ctx = assume_proc_decl ctx ~no_constraint p in
+  let ctx = assume_proc_decl st ctx ~no_constraint p in
   let bvlocks =
     Procedure.iter_blocks_topo_fwd p
-    |> Iter.map (fun (i, b) -> (i, infer_block vc prog univ ctx b))
+    |> Iter.map (fun (i, b) -> (i, infer_block st vc prog univ ctx b))
     |> Iter.persistent
   in
 
@@ -123,36 +119,38 @@ let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
     Procedure.set_specification p (new_spec ctx)
     |> (fun p ->
     bvlocks
-    |> Iter.map (fun (bid, b) -> (bid, elaborate_block [%here] univ ctx b))
+    |> Iter.map (fun (bid, b) -> (bid, elaborate_block st [%here] univ ctx b))
     |> Iter.fold (fun p (bid, b) -> Procedure.update_block p bid b) p)
-    |> Procedure.map_formal_in_params (StringMap.map (retype_var univ ctx))
-    |> Procedure.map_formal_out_params (StringMap.map (retype_var univ ctx))
+    |> Procedure.map_formal_in_params (StringMap.map (retype_var st univ ctx))
+    |> Procedure.map_formal_out_params (StringMap.map (retype_var st univ ctx))
   in
   Logs.debug (fun m -> m "%s" (ctx_to_string ctx));
   (elaborate_proc, ctx)
 
 (** Run type inference on a declaration, returning an updated typing scheme, and
     elaboration function*)
-let infer_decl visit_constraint prog scheme =
+let infer_decl st visit_constraint prog scheme =
   let open Program in
-  let infer_expr = infer_expr visit_constraint in
-  let infer_proc = infer_proc visit_constraint in
+  let infer_expr = infer_expr st visit_constraint in
+  let infer_proc = infer_proc st visit_constraint in
   (* We have to be careful that inference is run immediately, not delayed until elaboration. *)
   fun (decl_id, d) ->
     match d with
     | Type { binding; typ } ->
-        let ty = ty_of_basil typ in
-        let scheme = decl_type scheme binding ty in
-        let nty scheme = Type { binding; typ = to_basil (find ty) } in
+        let ty = ty_of_basil st typ in
+        let scheme = decl_type st scheme binding ty in
+        let nty scheme =
+          Type { binding; typ = to_basil (TypeExpr.find st ty) }
+        in
         (scheme, `Decl (decl_id, nty))
     | Function { binding; definition; attrib } -> (
         (* elaboration of var binding *)
-        let scheme = decl_var_typ global_universe scheme binding in
-        let binding s = retype_var global_universe s binding in
+        let scheme = decl_var_typ st global_universe scheme binding in
+        let binding s = retype_var st global_universe s binding in
         match definition with
         | Axiom b ->
             let b = infer_expr ~univ:global_universe [%here] b scheme in
-            let _ = unify (getty b) bool_type in
+            let _ = unify st (getty b) (bool_type st) in
             let new_axiom scheme =
               Function
                 {
@@ -160,7 +158,7 @@ let infer_decl visit_constraint prog scheme =
                   binding = binding scheme;
                   definition =
                     Axiom
-                      (elaborate_expr ~univ:global_universe [%here] b scheme);
+                      (elaborate_expr st ~univ:global_universe [%here] b scheme);
                 }
             in
             (scheme, `Decl (decl_id, new_axiom))
@@ -181,13 +179,13 @@ let infer_decl visit_constraint prog scheme =
                   attrib;
                   definition =
                     Function
-                      (elaborate_expr ~univ:global_universe [%here] e scheme);
+                      (elaborate_expr st ~univ:global_universe [%here] e scheme);
                 }
             in
             (scheme, `Decl (decl_id, new_fundef)))
     | Variable { binding; attrib; classification } ->
-        let scheme = decl_var_typ global_universe scheme binding in
-        let binding s = retype_var global_universe s binding in
+        let scheme = decl_var_typ st global_universe scheme binding in
+        let binding s = retype_var st global_universe s binding in
         let classification =
           let tyv =
             classification
@@ -197,7 +195,7 @@ let infer_decl visit_constraint prog scheme =
           fun final_scheme ->
             tyv
             |> Option.map (fun e ->
-                elaborate_expr ~univ:global_universe [%here] e final_scheme)
+                elaborate_expr st ~univ:global_universe [%here] e final_scheme)
         in
         let new_vardef fscheme =
           Variable
@@ -213,7 +211,7 @@ let infer_decl visit_constraint prog scheme =
         (scheme, `Procedure (decl_id, elaborate_proc))
 
 (** The function that does everything *)
-let infer_program prog =
+let infer_program st prog =
   let decls = Program.declarations prog |> Iter.to_list in
   let constraints = ref [] in
   let visit_constraint c = constraints := c :: !constraints in
@@ -224,9 +222,9 @@ let infer_program prog =
     expressions back to bincaml typed expressions. *)
   let scheme, new_decls =
     decls
-    |> List.fold_map (infer_decl visit_constraint prog) TypeExpr.TCtx.empty
+    |> List.fold_map (infer_decl st visit_constraint prog) TypeExpr.TCtx.empty
   in
-  let _ = solve_constraints ~max_iters:50 !constraints in
+  let _ = solve_constraints st ~max_iters:50 !constraints in
   (* TODO: implicit decls; constructors need to be added after the types they
     construct, probably simples to do implicits immediately after the thing they
     relate to. Maybe they should just appear this way in the declaration

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -46,7 +46,7 @@ let elaborate_expr st ~univ (hr : Lexing.position) e
     let t = AbstractExpr.get_typ e |> TypeExpr.find st |> to_basil in
     AbstractExpr.set_typ e t |> Expr.BasilExpr.fix
   in
-  e |> TypingExpr.cata alg
+  e |> AbsTypingExpr.cata alg
 
 let elaborate_stmt st univ ctx stmt =
   let retype_var = retype_var st univ ctx in

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -3,251 +3,246 @@ open Abstract_expr
 
 (** Hindley-Milner type inference based on a union-find. *)
 
-module TypeInference (T : TypeExpr.TypeContext) = struct
-  open Hm_types.Make (T)
-  open Unification.Make (T)
-  open Inference.Make (T)
-  open Solve_bv.Make (T)
-  open T
-  open T.Typ
+open Hm_types
+open Unification
+open Inference
+open Solve_bv
 
-  let retype_var univ ctx id =
-    lookup_var_typ ~no_constraint:true univ ctx id |> find |> to_basil
-    |> fun typ -> Var.copy ~typ id
+let retype_var univ ctx id =
+  lookup_var_typ ~no_constraint:true univ ctx id |> find |> to_basil
+  |> fun typ -> Var.copy ~typ id
 
-  let elaborate_phi univ ctx (p : Var.t Block.phi list) =
-    let open Block in
-    List.map
-      (fun { lhs; rhs } ->
-        let lhs = retype_var univ ctx lhs in
-        let rhs = List.map (fun (a, r) -> (a, retype_var univ ctx r)) rhs in
-        { lhs; rhs })
-      p
+let elaborate_phi univ ctx (p : Var.t Block.phi list) =
+  let open Block in
+  List.map
+    (fun { lhs; rhs } ->
+      let lhs = retype_var univ ctx lhs in
+      let rhs = List.map (fun (a, r) -> (a, retype_var univ ctx r)) rhs in
+      { lhs; rhs })
+    p
 
-  let ctx_to_string ctx =
-    TypeExpr.TCtx.to_iter ctx
-    |> Iter.to_string (fun (a, b) ->
-        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
+let ctx_to_string ctx =
+  TypeExpr.TCtx.to_iter ctx
+  |> Iter.to_string (fun (a, b) ->
+      Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
 
-  let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
-  let unfix i = match i with Expr.BasilExpr.E i -> i
-  let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
+let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
+let unfix i = match i with Expr.BasilExpr.E i -> i
+let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
 
-  (** Extract type after full inference has run. *)
-  let elaborate_expr ~univ (hr : Lexing.position) e (c : scheme TypeExpr.TCtx.t)
-      =
-    let alg e =
-      let e =
-        match e with
-        | AbstractExpr.RVar { id; attrib; typ } ->
-            (* avoid looking up the id in context as we may be in a local
+(** Extract type after full inference has run. *)
+let elaborate_expr ~univ (hr : Lexing.position) e (c : scheme TypeExpr.TCtx.t) =
+  let alg e =
+    let e =
+      match e with
+      | AbstractExpr.RVar { id; attrib; typ } ->
+          (* avoid looking up the id in context as we may be in a local
             binding *)
-            let id = Var.copy id ~typ:(to_basil @@ find typ) in
-            AbstractExpr.RVar { id; attrib; typ }
-        | o -> o
-      in
-      let t = AbstractExpr.get_typ e |> find |> to_basil in
-      AbstractExpr.set_typ e t |> Expr.BasilExpr.fix
+          let id = Var.copy id ~typ:(to_basil @@ find typ) in
+          AbstractExpr.RVar { id; attrib; typ }
+      | o -> o
     in
-    e |> TypingExpr.cata alg
+    let t = AbstractExpr.get_typ e |> find |> to_basil in
+    AbstractExpr.set_typ e t |> Expr.BasilExpr.fix
+  in
+  e |> TypingExpr.cata alg
 
-  let elaborate_stmt univ ctx stmt =
-    let retype_var v =
-      let typ =
-        lookup_var_typ ~no_constraint:true univ ctx v |> find |> to_basil
-      in
-      Var.copy ~typ v
+let elaborate_stmt univ ctx stmt =
+  let retype_var v =
+    let typ =
+      lookup_var_typ ~no_constraint:true univ ctx v |> find |> to_basil
     in
-    Stmt.map
-      ~f_expr:(fun e -> elaborate_expr ~univ [%here] e ctx)
-      ~f_lvar:retype_var ~f_rvar:retype_var stmt
+    Var.copy ~typ v
+  in
+  Stmt.map
+    ~f_expr:(fun e -> elaborate_expr ~univ [%here] e ctx)
+    ~f_lvar:retype_var ~f_rvar:retype_var stmt
 
-  let elaborate_block p univ ctx (b : ('a, 'b) Block.t) =
-    Block.map ~phi:(elaborate_phi univ ctx) (elaborate_stmt univ ctx) b
+let elaborate_block p univ ctx (b : ('a, 'b) Block.t) =
+  Block.map ~phi:(elaborate_phi univ ctx) (elaborate_stmt univ ctx) b
 
-  let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
-    let globs = Var.Decls.values (Procedure.local_decls p) in
-    let formals_in = Procedure.formal_in_params p |> StringMap.values in
-    let formals_out = Procedure.formal_out_params p |> StringMap.values in
-    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-    let ctx =
-      Iter.fold
-        (decl_var_typ ~no_constraint univ)
-        ctx
-        (Iter.append globs @@ Iter.append formals_in formals_out)
-    in
-    ctx
+let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
+  let globs = Var.Decls.values (Procedure.local_decls p) in
+  let formals_in = Procedure.formal_in_params p |> StringMap.values in
+  let formals_out = Procedure.formal_out_params p |> StringMap.values in
+  let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
+  let ctx =
+    Iter.fold
+      (decl_var_typ ~no_constraint univ)
+      ctx
+      (Iter.append globs @@ Iter.append formals_in formals_out)
+  in
+  ctx
 
-  let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
-    let spec = Procedure.specification p in
-    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-    let ibool_list b =
-      List.map
-        (fun a ->
-          let a = infer_expr vc ~univ [%here] a ctx in
-          let _ = unify bool_type (getty a) in
-          a)
-        b
-    in
-    let spec : ('a, 'b) Procedure.proc_spec =
-      {
-        requires = ibool_list spec.requires;
-        ensures = ibool_list spec.ensures;
-        rely = ibool_list spec.rely;
-        guarantee = ibool_list spec.guarantee;
-        captures_globs =
-          List.map (infer_var global_universe ctx) spec.captures_globs;
-        modifies_globs =
-          List.map (infer_var global_universe ctx) spec.modifies_globs;
-      }
-    in
+let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
+  let spec = Procedure.specification p in
+  let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
+  let ibool_list b =
+    List.map
+      (fun a ->
+        let a = infer_expr vc ~univ [%here] a ctx in
+        let _ = unify bool_type (getty a) in
+        a)
+      b
+  in
+  let spec : ('a, 'b) Procedure.proc_spec =
+    {
+      requires = ibool_list spec.requires;
+      ensures = ibool_list spec.ensures;
+      rely = ibool_list spec.rely;
+      guarantee = ibool_list spec.guarantee;
+      captures_globs =
+        List.map (infer_var global_universe ctx) spec.captures_globs;
+      modifies_globs =
+        List.map (infer_var global_universe ctx) spec.modifies_globs;
+    }
+  in
 
-    let new_spec ctx : (Var.t, Expr.BasilExpr.t) Procedure.proc_spec =
-      {
-        requires =
-          List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.requires;
-        ensures =
-          List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.ensures;
-        rely = List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.rely;
-        guarantee =
-          List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.guarantee;
-        captures_globs = spec.captures_globs |> List.map fst;
-        modifies_globs = spec.modifies_globs |> List.map fst;
-      }
-    in
+  let new_spec ctx : (Var.t, Expr.BasilExpr.t) Procedure.proc_spec =
+    {
+      requires =
+        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.requires;
+      ensures =
+        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.ensures;
+      rely = List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.rely;
+      guarantee =
+        List.map (fun e -> elaborate_expr ~univ [%here] e ctx) spec.guarantee;
+      captures_globs = spec.captures_globs |> List.map fst;
+      modifies_globs = spec.modifies_globs |> List.map fst;
+    }
+  in
 
-    let ctx = assume_proc_decl ctx ~no_constraint p in
-    let bvlocks =
-      Procedure.iter_blocks_topo_fwd p
-      |> Iter.map (fun (i, b) -> (i, infer_block vc prog univ ctx b))
-      |> Iter.persistent
-    in
+  let ctx = assume_proc_decl ctx ~no_constraint p in
+  let bvlocks =
+    Procedure.iter_blocks_topo_fwd p
+    |> Iter.map (fun (i, b) -> (i, infer_block vc prog univ ctx b))
+    |> Iter.persistent
+  in
 
-    let elaborate_proc ctx =
-      Procedure.set_specification p (new_spec ctx)
-      |> (fun p ->
-      bvlocks
-      |> Iter.map (fun (bid, b) -> (bid, elaborate_block [%here] univ ctx b))
-      |> Iter.fold (fun p (bid, b) -> Procedure.update_block p bid b) p)
-      |> Procedure.map_formal_in_params (StringMap.map (retype_var univ ctx))
-      |> Procedure.map_formal_out_params (StringMap.map (retype_var univ ctx))
-    in
-    Logs.debug (fun m -> m "%s" (ctx_to_string ctx));
-    (elaborate_proc, ctx)
+  let elaborate_proc ctx =
+    Procedure.set_specification p (new_spec ctx)
+    |> (fun p ->
+    bvlocks
+    |> Iter.map (fun (bid, b) -> (bid, elaborate_block [%here] univ ctx b))
+    |> Iter.fold (fun p (bid, b) -> Procedure.update_block p bid b) p)
+    |> Procedure.map_formal_in_params (StringMap.map (retype_var univ ctx))
+    |> Procedure.map_formal_out_params (StringMap.map (retype_var univ ctx))
+  in
+  Logs.debug (fun m -> m "%s" (ctx_to_string ctx));
+  (elaborate_proc, ctx)
 
-  (** Run type inference on a declaration, returning an updated typing scheme,
-      and elaboration function*)
-  let infer_decl visit_constraint prog scheme =
-    let open Program in
-    let infer_expr = infer_expr visit_constraint in
-    let infer_proc = infer_proc visit_constraint in
-    (* We have to be careful that inference is run immediately, not delayed until elaboration. *)
-    fun (decl_id, d) ->
-      match d with
-      | Type { binding; typ } ->
-          let ty = ty_of_basil typ in
-          let scheme = decl_type scheme binding ty in
-          let nty scheme = Type { binding; typ = to_basil (find ty) } in
-          (scheme, `Decl (decl_id, nty))
-      | Function { binding; definition; attrib } -> (
-          (* elaboration of var binding *)
-          let scheme = decl_var_typ global_universe scheme binding in
-          let binding s = retype_var global_universe s binding in
-          match definition with
-          | Axiom b ->
-              let b = infer_expr ~univ:global_universe [%here] b scheme in
-              let _ = unify (getty b) bool_type in
-              let new_axiom scheme =
-                Function
-                  {
-                    attrib;
-                    binding = binding scheme;
-                    definition =
-                      Axiom
-                        (elaborate_expr ~univ:global_universe [%here] b scheme);
-                  }
-              in
-              (scheme, `Decl (decl_id, new_axiom))
-          | Uninterpreted ->
-              let new_uf s =
-                Function
-                  { binding = binding s; attrib; definition = Uninterpreted }
-              in
-              (scheme, `Decl (decl_id, new_uf))
-          | Function definition ->
-              let e =
-                infer_expr ~univ:global_universe [%here] definition scheme
-              in
-              let new_fundef scheme =
-                Function
-                  {
-                    binding = binding scheme;
-                    attrib;
-                    definition =
-                      Function
-                        (elaborate_expr ~univ:global_universe [%here] e scheme);
-                  }
-              in
-              (scheme, `Decl (decl_id, new_fundef)))
-      | Variable { binding; attrib; classification } ->
-          let scheme = decl_var_typ global_universe scheme binding in
-          let binding s = retype_var global_universe s binding in
-          let classification =
-            let tyv =
-              classification
-              |> Option.map (fun classi ->
-                  infer_expr ~univ:global_universe [%here] classi scheme)
+(** Run type inference on a declaration, returning an updated typing scheme, and
+    elaboration function*)
+let infer_decl visit_constraint prog scheme =
+  let open Program in
+  let infer_expr = infer_expr visit_constraint in
+  let infer_proc = infer_proc visit_constraint in
+  (* We have to be careful that inference is run immediately, not delayed until elaboration. *)
+  fun (decl_id, d) ->
+    match d with
+    | Type { binding; typ } ->
+        let ty = ty_of_basil typ in
+        let scheme = decl_type scheme binding ty in
+        let nty scheme = Type { binding; typ = to_basil (find ty) } in
+        (scheme, `Decl (decl_id, nty))
+    | Function { binding; definition; attrib } -> (
+        (* elaboration of var binding *)
+        let scheme = decl_var_typ global_universe scheme binding in
+        let binding s = retype_var global_universe s binding in
+        match definition with
+        | Axiom b ->
+            let b = infer_expr ~univ:global_universe [%here] b scheme in
+            let _ = unify (getty b) bool_type in
+            let new_axiom scheme =
+              Function
+                {
+                  attrib;
+                  binding = binding scheme;
+                  definition =
+                    Axiom
+                      (elaborate_expr ~univ:global_universe [%here] b scheme);
+                }
             in
-            fun final_scheme ->
-              tyv
-              |> Option.map (fun e ->
-                  elaborate_expr ~univ:global_universe [%here] e final_scheme)
+            (scheme, `Decl (decl_id, new_axiom))
+        | Uninterpreted ->
+            let new_uf s =
+              Function
+                { binding = binding s; attrib; definition = Uninterpreted }
+            in
+            (scheme, `Decl (decl_id, new_uf))
+        | Function definition ->
+            let e =
+              infer_expr ~univ:global_universe [%here] definition scheme
+            in
+            let new_fundef scheme =
+              Function
+                {
+                  binding = binding scheme;
+                  attrib;
+                  definition =
+                    Function
+                      (elaborate_expr ~univ:global_universe [%here] e scheme);
+                }
+            in
+            (scheme, `Decl (decl_id, new_fundef)))
+    | Variable { binding; attrib; classification } ->
+        let scheme = decl_var_typ global_universe scheme binding in
+        let binding s = retype_var global_universe s binding in
+        let classification =
+          let tyv =
+            classification
+            |> Option.map (fun classi ->
+                infer_expr ~univ:global_universe [%here] classi scheme)
           in
-          let new_vardef fscheme =
-            Variable
-              {
-                binding = binding fscheme;
-                attrib;
-                classification = classification fscheme;
-              }
-          in
-          (scheme, `Decl (decl_id, new_vardef))
-      | Procedure { definition } ->
-          let elaborate_proc, scheme = infer_proc prog scheme definition in
-          (scheme, `Procedure (decl_id, elaborate_proc))
+          fun final_scheme ->
+            tyv
+            |> Option.map (fun e ->
+                elaborate_expr ~univ:global_universe [%here] e final_scheme)
+        in
+        let new_vardef fscheme =
+          Variable
+            {
+              binding = binding fscheme;
+              attrib;
+              classification = classification fscheme;
+            }
+        in
+        (scheme, `Decl (decl_id, new_vardef))
+    | Procedure { definition } ->
+        let elaborate_proc, scheme = infer_proc prog scheme definition in
+        (scheme, `Procedure (decl_id, elaborate_proc))
 
-  (** The function that does everything *)
-  let infer_program prog =
-    let decls = Program.declarations prog |> Iter.to_list in
-    let constraints = ref [] in
-    let visit_constraint c = constraints := c :: !constraints in
-    (* We fold the inference context through every declaration and
+(** The function that does everything *)
+let infer_program prog =
+  let decls = Program.declarations prog |> Iter.to_list in
+  let constraints = ref [] in
+  let visit_constraint c = constraints := c :: !constraints in
+  (* We fold the inference context through every declaration and
     calling the inference functions, returning an expressions typed with the
     type expressions herein.  We also return the resulting list of elaboration
     functions, which take the final inference context and convert the HM-typed
     expressions back to bincaml typed expressions. *)
-    let scheme, new_decls =
-      decls
-      |> List.fold_map (infer_decl visit_constraint prog) TypeExpr.TCtx.empty
-    in
-    let _ = solve_constraints ~max_iters:50 !constraints in
-    (* TODO: implicit decls; constructors need to be added after the types they
+  let scheme, new_decls =
+    decls
+    |> List.fold_map (infer_decl visit_constraint prog) TypeExpr.TCtx.empty
+  in
+  let _ = solve_constraints ~max_iters:50 !constraints in
+  (* TODO: implicit decls; constructors need to be added after the types they
     construct, probably simples to do implicits immediately after the thing they
     relate to. Maybe they should just appear this way in the declaration
     list. *)
-    let prog =
-      List.fold_left
-        (fun prog -> function
-          | `Decl (id, ndecl) ->
-              let decl = ndecl scheme in
-              (* assuming the id is the same (it has to be) *)
-              Program.update_decl prog decl
-          | `Procedure (id, nproc) ->
-              let proc = nproc scheme in
-              (* assuming the id is the same (it has to be) *)
-              let prog = Program.update_proc id (fun _ -> Some proc) prog in
-              prog)
-        prog new_decls
-    in
-    (scheme, prog)
-end
+  let prog =
+    List.fold_left
+      (fun prog -> function
+        | `Decl (id, ndecl) ->
+            let decl = ndecl scheme in
+            (* assuming the id is the same (it has to be) *)
+            Program.update_decl prog decl
+        | `Procedure (id, nproc) ->
+            let proc = nproc scheme in
+            (* assuming the id is the same (it has to be) *)
+            let prog = Program.update_proc id (fun _ -> Some proc) prog in
+            prog)
+      prog new_decls
+  in
+  (scheme, prog)

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -140,19 +140,33 @@ module Elaboration = Elaboration
     This module implements both inference and elaboratino for the high-level
     program structures as this simplifies book-keeping of types. *)
 
-(** {1 High-level type-inference operations}*)
-
 open Common
 open Abstract_expr
 
-module Hm_make_fresh () = struct
-  module Ctx = TypeExpr.MakeFresh ()
-  include Hm_types.Make (Ctx)
-  include Unification.Make (Ctx)
-  include Inference.Make (Ctx)
-  include Solve_bv.Make (Ctx)
-  include Elaboration.TypeInference (Ctx)
+(** Convenience module including all HM submodules. *)
+module Everything = struct
+  include Hm_types
+  (** @closed *)
+
+  include Unification
+  (** @closed *)
+
+  include Inference
+  (** @closed *)
+
+  include Solve_bv
+  (** @closed *)
+
+  include Elaboration
+  (** @closed *)
 end
+
+(** {2 Union-find / hash-cons state} *)
+
+include TypeExpr.State
+(** @inline *)
+
+(** {1 High-level type-inference operations} *)
 
 (*
    TODO:
@@ -174,19 +188,19 @@ end
 let locally_elaborate_expr (e : Expr.BasilExpr.t) =
   let open AbstractExpr in
   let open Ops.AllOps in
-  let module T = Hm_make_fresh () in
+  let st = create_state () in
   let constraints = ref [] in
   let univ = "<expr local>" in
   let ctx =
     Expr.BasilExpr.free_vars_iter e
-    |> Iter.fold (T.decl_var_typ univ) TypeExpr.TCtx.empty
+    |> Iter.fold (Unification.decl_var_typ st univ) TypeExpr.TCtx.empty
   in
   let visit_constraint c = constraints := c :: !constraints in
   (* TODO: need mode where we absorb take the existing annotations and try to
   extend , rather than expecting everythign declared in context. *)
-  let i = T.infer_expr visit_constraint ~univ [%here] e ctx in
-  let _ = T.solve_constraints ~max_iters:100 !constraints in
-  let e = T.elaborate_expr ~univ [%here] i ctx in
+  let i = Inference.infer_expr st visit_constraint ~univ [%here] e ctx in
+  let _ = Solve_bv.solve_constraints st ~max_iters:100 !constraints in
+  let e = Elaboration.elaborate_expr st ~univ [%here] i ctx in
   e
 
 (** Algebra for returning the annotated type (for use with functions like
@@ -197,15 +211,15 @@ let elaborated_type_alg (e : Types.t Expr.BasilExpr.abstract_expr) =
 (** Partially apply args list to function type funtype and return resulting type
 *)
 let type_applied (funtype : Types.t) (args : Types.t list) =
-  let module T = Hm_make_fresh () in
-  let rt = T.fresh_tvar ~n:"ret" () in
-  let args = List.map T.ty_of_basil args in
+  let st = create_state () in
+  let rt = Inference.fresh_tvar st ~n:"ret" () in
+  let args = List.map (Hm_types.ty_of_basil st) args in
 
-  let funt = T.curry_f args rt in
-  let ft = T.ty_of_basil funtype in
+  let funt = Hm_types.curry_f st args rt in
+  let ft = Hm_types.ty_of_basil st funtype in
   try
-    T.unify ~pos:[%here] ft funt |> ignore;
-    Ok (T.to_basil rt)
+    Unification.unify st ~pos:[%here] ft funt |> ignore;
+    Ok (Hm_types.to_basil rt)
   with Hm_types.TypeErr e -> Error e
 
 (** Apply type inference to a program and return a fully type-annotated copy of
@@ -213,6 +227,6 @@ let type_applied (funtype : Types.t) (args : Types.t list) =
 let elaborate_prog prog =
   (* We need to create a local typing module in order to get fresh state for the
   union find and hash cons. *)
-  let module T = Hm_make_fresh () in
-  let scheme, prog = T.infer_program prog in
+  let st = create_state () in
+  let scheme, prog = Elaboration.infer_program st prog in
   prog

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -11,6 +11,8 @@
     - {:https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Algorithm_J}
     - {:https://bernsteinbear.com/blog/type-inference/} *)
 
+module State = State
+
 module TypeExpr = TypeExpr
 (** {1 Type Expressions}
 

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -11,8 +11,6 @@
     - {:https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Algorithm_J}
     - {:https://bernsteinbear.com/blog/type-inference/} *)
 
-module State = State
-
 module TypeExpr = TypeExpr
 (** {1 Type Expressions}
 

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -5,109 +5,104 @@ open Abstract_expr
 
 exception TypeErr of string
 
-module Make (Ctx : TypeExpr.TypeContext) = struct
-  type typ = Ctx.Typ.t [@@deriving eq, ord]
-
-  (** Recursion algebra for printing types *)
-  let printer_alg = function
-    | TypeExpr.ATyp.Var e -> ID.to_string e
-    | TypeConstr ([ l ], e) -> l ^ " " ^ e
-    | TypeConstr ([ a; b ], "->") -> a ^ " -> " ^ b
-    | TypeConstr ([], e) -> e
-    | TypeConstr (ls, e) ->
-        List.to_string ~start:"(" ~stop:")" ~sep:"," Fun.id ls ^ " " ^ e
-
-  let type_to_string t = Ctx.Rec.cata printer_alg t
-
-  let plpos (l : Lexing.position) =
-    Printf.sprintf "%s:%d" l.pos_fname l.pos_lnum
-
-  (** Type schemes; how values of the typing context are typed. *)
-  type scheme = Forall of TypeExpr.tvar list * Ctx.Typ.t
-
-  let scheme_to_string = function
-    | Forall (tl, t) ->
-        List.to_string ID.to_string tl ^ ". " ^ type_to_string (Ctx.Typ.find t)
-
-  (** Function type, takes two arguments: we always curry. *)
-  let fun_type a b = Ctx.Typ.fix (TypeConstr ([ a; b ], "->"))
-
-  (** A type representing a number *)
-  let nat_val_type i =
-    let num = Ctx.Typ.fix (TypeExpr.ATyp.TypeConstr ([], Int.to_string i)) in
-    Ctx.Typ.fix (TypeConstr ([ num ], "ℕ"))
-
-  let is_nat_val_type (i : Ctx.Typ.t) =
-    match Ctx.Typ.unfix i with
-    | TypeConstr ([ num ], "ℕ") -> (
-        match Ctx.Typ.unfix num with
-        | TypeConstr ([], num) -> Int.of_string num
-        | _ -> None)
-    | _ -> None
-
-  (** A bitvector type parametric in its width *)
-  let bv_type i = Ctx.Typ.fix (TypeConstr ([ nat_val_type i ], "bv"))
-
-  (** Bitvector of arbitrary size *)
-  let bvunk i = Ctx.Typ.fix (TypeConstr ([ i ], "bv"))
-
-  (** {2 Primitive types} *)
-
-  let int_type = Ctx.Typ.fix (TypeConstr ([], "int"))
-  let bool_type = Ctx.Typ.fix (TypeConstr ([], "bool"))
-  let unit_t = Ctx.Typ.fix (TypeConstr ([], "unit"))
-  let top_t = Ctx.Typ.fix (TypeConstr ([], "top"))
-  let nothing_t = Ctx.Typ.fix (TypeConstr ([], "nothing"))
-  let ptr_typ_sub a b = Ctx.Typ.fix (TypeConstr ([ a; b ], "ptr"))
-  let ptr_typ = bv_type 64
-
-  let rec to_basil (t : Ctx.Typ.t) : Types.t =
-    let wrapped t f =
-      try f ()
-      with TypeErr e ->
-        raise (TypeErr ("error in " ^ (type_to_string @@ t) ^ ": " ^ e))
-    in
-    let open Types in
-    wrapped t @@ fun () ->
-    match Ctx.Typ.unfix t with
-    | TypeConstr ([ a; b ], "->") ->
-        let a = wrapped a @@ fun () -> to_basil a in
-        let b = wrapped b @@ fun () -> to_basil b in
-        Map (a, b)
-    | TypeConstr ([ w ], "bv") -> (
-        match is_nat_val_type w with
-        | Some i -> Bitvector i
-        | None -> raise (TypeErr ("bitvector unresolved: " ^ type_to_string t)))
-    | TypeConstr ([], "unit") -> Unit
-    | TypeConstr ([], "bool") -> Boolean
-    | TypeConstr ([], "int") -> Integer
-    | TypeConstr ([], "top") -> Top
-    | TypeConstr ([], "nothing") -> Nothing
-    | TypeConstr ([], o) -> Sort (o, [])
-    | _ -> failwith "not impl"
-
-  let rec ty_of_basil (t : Types.t) : Ctx.Typ.t =
-    match t with
-    | Types.Boolean -> bool_type
-    | Types.Integer -> int_type
-    | Types.Bitvector i -> bv_type i
-    | Types.Unit -> unit_t
-    | Types.Top -> top_t
-    | Types.Nothing -> nothing_t
-    | Types.Map (a, b) -> fun_type (ty_of_basil a) (ty_of_basil b)
-    | Types.Sort (n, _) -> Ctx.Typ.fix (TypeConstr ([], n))
-    | Types.Struct _ -> failwith "unsupp"
-    | Types.Pointer { lower; upper } ->
-        ptr_typ_sub (ty_of_basil lower) (ty_of_basil upper)
-    | Types.Variable n -> Ctx.Typ.fix (Var (Ctx.gen.fresh ~name:n ()))
-
-  let curry (args : Ctx.Typ.t TypeExpr.ATyp.expr list)
-      (v : Ctx.Typ.t TypeExpr.ATyp.expr) =
-    List.fold_left (fun a p -> fun_type (Ctx.Typ.fix p) a) (Ctx.Typ.fix v) args
-
-  let curry_f (args : Ctx.Typ.t list) (v : Ctx.Typ.t) =
-    List.fold_left (fun a p -> fun_type p a) v args
-
-  let types_universe = "<types>"
-  let global_universe = "<global>"
+open struct
+  let fix = TypeExpr.fix
 end
+
+(** Function type, takes two arguments: we always curry. *)
+let fun_type st a b = fix st (TypeConstr ([ a; b ], "->"))
+
+(** A type representing a number *)
+let nat_val_type st i =
+  let num = fix st (TypeExpr.ATyp.TypeConstr ([], Int.to_string i)) in
+  fix st (TypeConstr ([ num ], "ℕ"))
+
+(** A bitvector type parametric in its width *)
+let bv_type st i = fix st (TypeConstr ([ nat_val_type st i ], "bv"))
+
+(** Bitvector of arbitrary size *)
+let bvunk st i = fix st (TypeConstr ([ i ], "bv"))
+
+(** {2 Primitive types} *)
+
+let int_type st = fix st (TypeConstr ([], "int"))
+let bool_type st = fix st (TypeConstr ([], "bool"))
+let unit_t st = fix st (TypeConstr ([], "unit"))
+let top_t st = fix st (TypeConstr ([], "top"))
+let nothing_t st = fix st (TypeConstr ([], "nothing"))
+let ptr_typ_sub st a b = fix st (TypeConstr ([ a; b ], "ptr"))
+let ptr_typ st = bv_type st 64
+
+let curry_f st (args : TypeExpr.t list) (v : TypeExpr.t) =
+  List.fold_left (fun a p -> fun_type st p a) v args
+
+let rec ty_of_basil st (t : Types.t) : TypeExpr.t =
+  match t with
+  | Types.Boolean -> bool_type st
+  | Types.Integer -> int_type st
+  | Types.Bitvector i -> bv_type st i
+  | Types.Unit -> unit_t st
+  | Types.Top -> top_t st
+  | Types.Nothing -> nothing_t st
+  | Types.Map (a, b) -> fun_type st (ty_of_basil st a) (ty_of_basil st b)
+  | Types.Sort (n, _) -> fix st (TypeConstr ([], n))
+  | Types.Struct _ -> failwith "unsupp"
+  | Types.Pointer { lower; upper } ->
+      ptr_typ_sub st (ty_of_basil st lower) (ty_of_basil st upper)
+  | Types.Variable n -> fix st (Var (st.gen.fresh ~name:n ()))
+
+let is_nat_val_type (i : TypeExpr.t) =
+  match TypeExpr.unfix i with
+  | TypeConstr ([ num ], "ℕ") -> (
+      match TypeExpr.unfix num with
+      | TypeConstr ([], num) -> Int.of_string num
+      | _ -> None)
+  | _ -> None
+
+type typ = TypeExpr.t [@@deriving eq, ord]
+
+(** Recursion algebra for printing types *)
+let printer_alg = function
+  | TypeExpr.ATyp.Var e -> ID.to_string e
+  | TypeConstr ([ l ], e) -> l ^ " " ^ e
+  | TypeConstr ([ a; b ], "->") -> a ^ " -> " ^ b
+  | TypeConstr ([], e) -> e
+  | TypeConstr (ls, e) ->
+      List.to_string ~start:"(" ~stop:")" ~sep:"," Fun.id ls ^ " " ^ e
+
+let type_to_string t = TypeExpr.cata printer_alg t
+let plpos (l : Lexing.position) = Printf.sprintf "%s:%d" l.pos_fname l.pos_lnum
+
+(** Type schemes; how values of the typing context are typed. *)
+type scheme = Forall of TypeExpr.tvar list * TypeExpr.t
+
+let scheme_to_string = function
+  | Forall (tl, t) -> List.to_string ID.to_string tl ^ ". " ^ type_to_string t
+
+let rec to_basil (t : TypeExpr.t) : Types.t =
+  let wrapped t f =
+    try f ()
+    with TypeErr e ->
+      raise (TypeErr ("error in " ^ (type_to_string @@ t) ^ ": " ^ e))
+  in
+  let open Types in
+  wrapped t @@ fun () ->
+  match TypeExpr.unfix t with
+  | TypeConstr ([ a; b ], "->") ->
+      let a = wrapped a @@ fun () -> to_basil a in
+      let b = wrapped b @@ fun () -> to_basil b in
+      Map (a, b)
+  | TypeConstr ([ w ], "bv") -> (
+      match is_nat_val_type w with
+      | Some i -> Bitvector i
+      | None -> raise (TypeErr ("bitvector unresolved: " ^ type_to_string t)))
+  | TypeConstr ([], "unit") -> Unit
+  | TypeConstr ([], "bool") -> Boolean
+  | TypeConstr ([], "int") -> Integer
+  | TypeConstr ([], "top") -> Top
+  | TypeConstr ([], "nothing") -> Nothing
+  | TypeConstr ([], o) -> Sort (o, [])
+  | _ -> failwith "not impl"
+
+let types_universe = "<types>"
+let global_universe = "<global>"

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -51,6 +51,34 @@ let rec ty_of_basil st (t : Types.t) : TypeExpr.t =
       ptr_typ_sub st (ty_of_basil st lower) (ty_of_basil st upper)
   | Types.Variable n -> fix st (Var (st.gen.fresh ~name:n ()))
 
+module Make_smart_constructors (S : sig
+  val state : TypeExpr.state
+end) =
+struct
+  let fun_type = fun_type S.state
+  let nat_val_type = nat_val_type S.state
+  let bv_type = bv_type S.state
+  let bvunk = bvunk S.state
+  let int_type = int_type S.state
+  let bool_type = bool_type S.state
+  let unit_t = unit_t S.state
+  let top_t = top_t S.state
+  let nothing_t = nothing_t S.state
+  let ptr_typ_sub = ptr_typ_sub S.state
+  let ptr_typ = ptr_typ S.state
+  let curry_f = curry_f S.state
+  let ty_of_basil = ty_of_basil S.state
+end
+
+module type Smart_constructors = module type of Make_smart_constructors (struct
+  let state = TypeExpr.create_state ()
+end)
+
+let smart_constructors st : (module Smart_constructors) =
+  (module Make_smart_constructors (struct
+    let state = st
+  end))
+
 let is_nat_val_type (i : TypeExpr.t) =
   match TypeExpr.unfix i with
   | TypeConstr ([ num ], "ℕ") -> (

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -87,8 +87,6 @@ let is_nat_val_type (i : TypeExpr.t) =
       | _ -> None)
   | _ -> None
 
-type typ = TypeExpr.t [@@deriving eq, ord]
-
 (** Recursion algebra for printing types *)
 let printer_alg = function
   | TypeExpr.ATyp.Var e -> ID.to_string e

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -1,343 +1,344 @@
 open Common
 open Abstract_expr
 open Hm_types
+open Unification
+open Solve_bv
 
 (** Hindley-Milner type inference based on a union-find. *)
 
-module Make (T : TypeExpr.TypeContext) = struct
-  open Solve_bv.Make (T)
-  open Hm_types.Make (T)
-  open Unification.Make (T)
-  open T
-  open T.Typ
+(** An AbstractExpr.t with [t] used as the type. *)
+module AbsTypingExpr = struct
+  open Ops
+  include AllOps
+  module Var = Var
 
-  (** An AbstractExpr.t with [t] used as the type. *)
-  module AbsTypingExpr = struct
-    open Ops
-    include AllOps
-    module Var = Var
+  type var = Var.t
 
-    type var = Var.t
+  type t = E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
+  [@@unboxed] [@@deriving eq, ord]
 
-    type t = E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
-    [@@unboxed] [@@deriving eq, ord]
+  type nonrec typ = typ
 
-    type nonrec typ = typ
-
-    let top_typ = top_t
-    let fix i = E i
-    let unfix i = match i with E i -> i
-  end
-
-  module TypingExpr = Expr.Make (AbsTypingExpr)
-
-  let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
-
-  let infer_var univ ctx id =
-    let typ = lookup_var_typ univ ctx id in
-    (id, typ)
-
-  (** Return the generic type scheme for an op. We generalise the type, and hope
-      dearly that a concrete type is found by inference.
-
-      TODO: some approach like weak type variables that makes it a type error to
-      fail to instantiate. *)
-  let scheme_of_op ~visit_constraint (gen : ID.generator)
-      (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
-    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-    match o with
-    | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
-    | `SignExtend bits ->
-        let a = fv () in
-        let equ = fv () in
-        let r = curry_f [ bvunk a ] (bvunk equ) in
-        visit_constraint @@ AddConst { a; b = bits; equ };
-        r
-    | `ZeroExtend bits ->
-        let a = fv () and equ = fv () in
-        visit_constraint @@ AddConst { a; b = bits; equ };
-        curry_f [ bvunk a ] (bvunk equ)
-    | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
-    | `Bitvector b -> bv_type (Bitvec.size b)
-    | #Ops.BVOps.binary_unif ->
-        let a = fv () in
-        curry_f [ bvunk a; bvunk a ] (bvunk a)
-    | #Ops.BVOps.binary_pred ->
-        let a = fv () in
-        curry_f [ bvunk a; bvunk a ] bool_type
-    | #Ops.BVOps.unary_unif ->
-        let a = fv () in
-        curry_f [ bvunk a ] (bvunk a)
-    | `INTNEG -> curry_f [ int_type ] int_type
-    | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
-    | #Ops.IntOps.const -> int_type
-    | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
-    | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
-    | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
-    | #Ops.LogicalOps.const -> bool_type
-    | `Old ->
-        let a = fv () in
-        curry_f [ a ] a
-    | #Ops.AllOps.binary as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-    | #Ops.AllOps.unary as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-    | #Ops.AllOps.const as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-
-  (** return the generic type scheme of an intrinsic operation *)
-  let scheme_of_intrin ?(visit_constraint = fun a -> ()) (gen : ID.generator)
-      (o : Ops.AllOps.intrin) args =
-    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-    match o with
-    | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
-        let a = fv () in
-        curry_f (List.init args (fun _ -> a)) a
-    | `BVConcat ->
-        let args = List.init args (fun _ -> fv ()) in
-        let rs =
-          List.reduce_exn
-            (fun a b ->
-              let equ = fv () in
-              visit_constraint (Add { a; b; equ });
-              equ)
-            args
-        in
-        let rs = bvunk rs in
-        let args = List.map bvunk args in
-        curry_f args rs
-    | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
-    | `MapUpdate ->
-        let a = fv () in
-        let b = fv () in
-        let m = curry_f [ a ] b in
-        curry_f [ m; a; b ] m
-    | `Cases -> fv ()
-
-  let do_infer ~visit_constraint
-      (infer :
-        univ:string ->
-        Lexing.position ->
-        Program.e ->
-        scheme TypeExpr.TCtx.t ->
-        AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
-    let mkv v = TypeExpr.V.of_var univ v in
-    let r = fix @@ Var (gen.fresh ()) in
-    let open Abstract_expr.AbstractExpr in
-    let e = Expr.BasilExpr.unfix e in
-    let e = set_typ e r in
-    match e with
-    | RVar { id; attrib } ->
-        let typ = lookup_var_typ univ c id in
-        AbsTypingExpr.fix (RVar { attrib; id; typ })
-    | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
-        let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
-        let ictx =
-          List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
-          |> TypeExpr.TCtx.add_list c
-        in
-        let bdty = infer ~univ [%here] in_body ictx in
-        let typ =
-          match op with
-          | `Lambda -> getty bdty
-          | `Forall | `Exists -> unify (getty bdty) bool_type
-        in
-        ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
-        let triggers =
-          List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
-        in
-        AbsTypingExpr.fix
-          (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
-      end
-    | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let r = unify r f in
-        AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
-      end
-    | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let arg = infer ~univ [%here] arg c in
-        ignore @@ unify f (curry_f [ getty arg ] r);
-        AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
-      end
-    | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let arg1 = infer ~univ [%here] arg1 c in
-        let arg2 = infer ~univ [%here] arg2 c in
-        ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
-        AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
-      end
-    | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
-        let f = scheme_of_intrin ~visit_constraint gen op (List.length args) in
-        let args = List.map (fun a -> infer ~univ [%here] a c) args in
-        ignore @@ unify f (curry_f (List.map getty args) r);
-        AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
-      end
-    | ApplyFun { func; args; attrib } ->
-        let f = infer ~univ [%here] func c in
-        let args = List.map (fun a -> infer ~univ [%here] a c) args in
-        ignore @@ unify (getty f) (curry_f (List.map getty args) r);
-        AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
-    | Let _ -> failwith ""
-
-  let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
-   fun (c : scheme TypeExpr.TCtx.t) ->
-    Logs.debug (fun m ->
-        m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
-    let t =
-      try do_infer ~visit_constraint (infer_expr visit_constraint) univ hr e c
-      with TypeErr m ->
-        raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
-    in
-    t
-
-  let infer visit_constraint ~univ (hr : Lexing.position) e
-      (c : scheme TypeExpr.TCtx.t) =
-    let nexpr =
-      infer_expr visit_constraint ~univ hr e c
-      |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
-    in
-    nexpr
-
-  let unfix i = match i with Expr.BasilExpr.E i -> i
-  let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
-
-  let infer_phi visit_constraint univ ctx (p : Var.t Block.phi list) =
-    let infer = infer visit_constraint in
-    let open Block in
-    let r = fix @@ Var (gen.fresh ()) in
-    List.fold_left
-      (fun acc { lhs; rhs } ->
-        let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
-        let e =
-          List.fold_left
-            (fun a (_, r) ->
-              let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
-              unify a r)
-            lhs rhs
-        in
-        unify acc e)
-      r p
-
-  let ctx_to_string ctx =
-    TypeExpr.TCtx.to_iter ctx
-    |> Iter.to_string (fun (a, b) ->
-        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
-
-  let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
-
-  let do_infer_stmt visit_constraint p univ ctx stmt =
-    let open Stmt in
-    let infer_ty h e = infer_expr visit_constraint ~univ h e ctx in
-    let infer = infer visit_constraint in
-
-    (*let r = fix @@ Var (gen.fresh ()) in*)
-    match stmt with
-    | Instr_IntrinCall _ -> failwith "intrin unsupported"
-    | Instr_Assume { body; branch; attrib } ->
-        let body = infer_ty [%here] body in
-        ignore @@ unify bool_type (getty body);
-        Instr_Assume { body; branch; attrib }
-    | Instr_Assert { body; attrib } ->
-        let body = infer_ty [%here] body in
-        ignore @@ unify bool_type (getty body);
-        Instr_Assert { body; attrib }
-    | Instr_Assign { al = ls; attrib } ->
-        let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
-        List.iter
-          (fun (l, r) ->
-            ignore
-            @@ unify (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx) (getty r))
-          ls;
-        Instr_Assign { al = ls; attrib }
-    | Instr_Call { lhs; procid; args; attrib } ->
-        let p = Program.proc p procid in
-        let infer_param p =
-          infer
-            ~univ:(TypeExpr.V.proc_univ procid)
-            [%here] (Expr.BasilExpr.rvar p) ctx
-        in
-        let args = StringMap.mapi (fun param a -> infer_ty [%here] a) args in
-        StringMap.iter
-          (fun parm act ->
-            let form =
-              infer_param (StringMap.find parm (Procedure.formal_in_params p))
-            in
-            ignore @@ unify form (getty act))
-          args;
-        lhs
-        |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
-        |> StringMap.iter (fun param act ->
-            let form =
-              infer_param (StringMap.find param @@ Procedure.formal_out_params p)
-            in
-            ignore @@ unify form (getty act));
-        Instr_Call { lhs; procid; args; attrib }
-    | Instr_IndirectCall { target; attrib } ->
-        let target = infer_ty [%here] target in
-        ignore @@ unify (getty target) ptr_typ;
-        Instr_IndirectCall { target; attrib }
-    | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
-        let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
-        let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
-        let _ = unify (getty lhs') (getty rhs') in
-        Instr_Load { lhs; rhs; addr = Scalar; attrib }
-    | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
-        let addr = infer_ty [%here] addr in
-        let _ = unify ptr_typ (getty addr) in
-        let mapt = fun_type (getty addr) (fresh_tvar ()) in
-        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-        let _ =
-          unify
-            (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
-            (bv_type size)
-        in
-        Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
-    | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
-        let value = infer_ty [%here] value in
-        let _ =
-          unify (getty value)
-          @@ unify
-               (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-               (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
-        in
-        Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
-    | Instr_Store
-        { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
-        let addr = infer_ty [%here] addr in
-        let _ = unify ptr_typ (getty addr) in
-        let mapt = fun_type (getty addr) (fresh_tvar ()) in
-        let _ =
-          unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-        in
-        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-        let value = infer_ty [%here] value in
-        let _ = unify (getty value) (bv_type size) in
-        Instr_Store
-          { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
-
-  let infer_stmt vc p univ ctx s =
-    try do_infer_stmt vc p univ ctx s
-    with TypeErr m ->
-      raise
-        (TypeErr
-           (m ^ " "
-           ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
-
-  let infer_block vc p univ ctx (b : Program.bloc) =
-    let _ = infer_phi vc univ ctx b.phis in
-    Block.map ~phi:Fun.id (infer_stmt vc p univ ctx) b
-
-  let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
-    let globs = Var.Decls.values (Procedure.local_decls p) in
-    let formals_in = Procedure.formal_in_params p |> StringMap.values in
-    let formals_out = Procedure.formal_out_params p |> StringMap.values in
-    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-    let ctx =
-      Iter.fold
-        (decl_var_typ ~no_constraint univ)
-        ctx
-        (Iter.append globs @@ Iter.append formals_in formals_out)
-    in
-    ctx
+  let top_typ = top_t
+  let fix i = E i
+  let unfix i = match i with E i -> i
 end
+
+(* module TypingExpr = Expr.Make (AbsTypingExpr) *)
+
+let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
+
+let infer_var univ ctx id =
+  let typ = lookup_var_typ univ ctx id in
+  (id, typ)
+
+(** Return the generic type scheme for an op. We generalise the type, and hope
+    dearly that a concrete type is found by inference.
+
+    TODO: some approach like weak type variables that makes it a type error to
+    fail to instantiate. *)
+let scheme_of_op st ~visit_constraint (gen : ID.generator)
+    (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
+  let open (val Hm_types.smart_constructors st) in
+  let fv () = TypeExpr.fix st @@ Var (gen.fresh ~name:"a" ()) in
+  match o with
+  | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
+  | `SignExtend bits ->
+      let a = fv () in
+      let equ = fv () in
+      let r = curry_f [ bvunk a ] (bvunk equ) in
+      visit_constraint @@ AddConst { a; b = bits; equ };
+      r
+  | `ZeroExtend bits ->
+      let a = fv () and equ = fv () in
+      visit_constraint @@ AddConst { a; b = bits; equ };
+      curry_f [ bvunk a ] (bvunk equ)
+  | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
+  | `Bitvector b -> bv_type (Bitvec.size b)
+  | #Ops.BVOps.binary_unif ->
+      let a = fv () in
+      curry_f [ bvunk a; bvunk a ] (bvunk a)
+  | #Ops.BVOps.binary_pred ->
+      let a = fv () in
+      curry_f [ bvunk a; bvunk a ] bool_type
+  | #Ops.BVOps.unary_unif ->
+      let a = fv () in
+      curry_f [ bvunk a ] (bvunk a)
+  | `INTNEG -> curry_f [ int_type ] int_type
+  | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
+  | #Ops.IntOps.const -> int_type
+  | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
+  | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
+  | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
+  | #Ops.LogicalOps.const -> bool_type
+  | `Old ->
+      let a = fv () in
+      curry_f [ a ] a
+  | #Ops.AllOps.binary as o ->
+      failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+  | #Ops.AllOps.unary as o ->
+      failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+  | #Ops.AllOps.const as o ->
+      failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+
+(** return the generic type scheme of an intrinsic operation *)
+let scheme_of_intrin st ?(visit_constraint = fun a -> ()) (gen : ID.generator)
+    (o : Ops.AllOps.intrin) args =
+  let fv () = TypeExpr.fix st @@ Var (gen.fresh ~name:"a" ()) in
+  match o with
+  | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
+      let a = fv () in
+      curry_f st (List.init args (fun _ -> a)) a
+  | `BVConcat ->
+      let args = List.init args (fun _ -> fv ()) in
+      let rs =
+        List.reduce_exn
+          (fun a b ->
+            let equ = fv () in
+            visit_constraint (Add { a; b; equ });
+            equ)
+          args
+      in
+      let rs = bvunk st rs in
+      let args = List.map (bvunk st) args in
+      curry_f st args rs
+  | `OR | `AND ->
+      curry_f st (List.init args (fun _ -> bool_type st)) (bool_type st)
+  | `MapUpdate ->
+      let a = fv () in
+      let b = fv () in
+      let m = curry_f st [ a ] b in
+      curry_f st [ m; a; b ] m
+  | `Cases -> fv ()
+
+let do_infer st ~visit_constraint
+    (infer :
+      univ:string ->
+      Lexing.position ->
+      Program.e ->
+      scheme TypeExpr.TCtx.t ->
+      AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
+  let unify = Unification.unify st
+  and curry_f = Hm_types.curry_f st
+  and scheme_of_op = scheme_of_op st
+  and scheme_of_intrin = scheme_of_intrin st
+  and gen = st.gen in
+
+  let mkv v = TypeExpr.V.of_var univ v in
+  let r = TypeExpr.fix st @@ Var (st.gen.fresh ()) in
+  let open Abstract_expr.AbstractExpr in
+  let e = Expr.BasilExpr.unfix e in
+  let e = set_typ e r in
+  match e with
+  | RVar { id; attrib } ->
+      let typ = lookup_var_typ st univ c id in
+      AbsTypingExpr.fix (RVar { attrib; id; typ })
+  | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
+      let tvars = List.map (fun v -> (v, inst_annot_v st v)) bound_vars in
+      let ictx =
+        List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
+        |> TypeExpr.TCtx.add_list c
+      in
+      let bdty = infer ~univ [%here] in_body ictx in
+      let typ =
+        match op with
+        | `Lambda -> getty bdty
+        | `Forall | `Exists -> unify (getty bdty) (bool_type st)
+      in
+      ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
+      let triggers =
+        List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
+      in
+      AbsTypingExpr.fix
+        (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
+    end
+  | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
+      let f = scheme_of_op ~visit_constraint gen op in
+      let r = unify r f in
+      AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
+    end
+  | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
+      let f = scheme_of_op ~visit_constraint gen op in
+      let arg = infer ~univ [%here] arg c in
+      ignore @@ unify f (curry_f [ getty arg ] r);
+      AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
+    end
+  | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } -> begin
+      let f = scheme_of_op ~visit_constraint gen op in
+      let arg1 = infer ~univ [%here] arg1 c in
+      let arg2 = infer ~univ [%here] arg2 c in
+      ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
+      AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
+    end
+  | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
+      let f = scheme_of_intrin ~visit_constraint gen op (List.length args) in
+      let args = List.map (fun a -> infer ~univ [%here] a c) args in
+      ignore @@ unify f (curry_f (List.map getty args) r);
+      AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
+    end
+  | ApplyFun { func; args; attrib } ->
+      let f = infer ~univ [%here] func c in
+      let args = List.map (fun a -> infer ~univ [%here] a c) args in
+      ignore @@ unify (getty f) (curry_f (List.map getty args) r);
+      AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
+  | Let _ -> failwith ""
+
+let rec infer_expr st visit_constraint ~univ (hr : Lexing.position) e =
+ fun (c : scheme TypeExpr.TCtx.t) ->
+  Logs.debug (fun m ->
+      m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
+  let t =
+    try
+      do_infer st ~visit_constraint (infer_expr st visit_constraint) univ hr e c
+    with TypeErr m -> raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
+  in
+  t
+
+let infer st visit_constraint ~univ (hr : Lexing.position) e
+    (c : scheme TypeExpr.TCtx.t) =
+  let nexpr =
+    infer_expr st visit_constraint ~univ hr e c
+    |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
+  in
+  nexpr
+
+let unfix i = match i with Expr.BasilExpr.E i -> i
+let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
+
+let infer_phi st visit_constraint univ ctx (p : Var.t Block.phi list) =
+  let infer = infer st visit_constraint in
+  let open Block in
+  let r = TypeExpr.fix st @@ Var (st.gen.fresh ()) in
+  List.fold_left
+    (fun acc { lhs; rhs } ->
+      let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
+      let e =
+        List.fold_left
+          (fun a (_, r) ->
+            let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
+            Unification.unify st a r)
+          lhs rhs
+      in
+      Unification.unify st acc e)
+    r p
+
+let ctx_to_string ctx =
+  TypeExpr.TCtx.to_iter ctx
+  |> Iter.to_string (fun (a, b) ->
+      Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
+
+let fresh_tvar st ?(n = "a") () =
+  TypeExpr.fix st @@ Var (st.gen.fresh ~name:n ())
+
+let do_infer_stmt st visit_constraint p univ ctx stmt =
+  let open Stmt in
+  let infer_ty h e = infer_expr st visit_constraint ~univ h e ctx
+  and infer = infer st visit_constraint
+  and unify = unify st in
+
+  (*let r = fix @@ Var (gen.fresh ()) in*)
+  match stmt with
+  | Instr_IntrinCall _ -> failwith "intrin unsupported"
+  | Instr_Assume { body; branch; attrib } ->
+      let body = infer_ty [%here] body in
+      ignore @@ unify (bool_type st) (getty body);
+      Instr_Assume { body; branch; attrib }
+  | Instr_Assert { body; attrib } ->
+      let body = infer_ty [%here] body in
+      ignore @@ unify (bool_type st) (getty body);
+      Instr_Assert { body; attrib }
+  | Instr_Assign { al = ls; attrib } ->
+      let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
+      List.iter
+        (fun (l, r) ->
+          ignore
+          @@ unify (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx) (getty r))
+        ls;
+      Instr_Assign { al = ls; attrib }
+  | Instr_Call { lhs; procid; args; attrib } ->
+      let p = Program.proc p procid in
+      let infer_param p =
+        infer
+          ~univ:(TypeExpr.V.proc_univ procid)
+          [%here] (Expr.BasilExpr.rvar p) ctx
+      in
+      let args = StringMap.mapi (fun param a -> infer_ty [%here] a) args in
+      StringMap.iter
+        (fun parm act ->
+          let form =
+            infer_param (StringMap.find parm (Procedure.formal_in_params p))
+          in
+          ignore @@ unify form (getty act))
+        args;
+      lhs
+      |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
+      |> StringMap.iter (fun param act ->
+          let form =
+            infer_param (StringMap.find param @@ Procedure.formal_out_params p)
+          in
+          ignore @@ unify form (getty act));
+      Instr_Call { lhs; procid; args; attrib }
+  | Instr_IndirectCall { target; attrib } ->
+      let target = infer_ty [%here] target in
+      ignore @@ unify (getty target) (ptr_typ st);
+      Instr_IndirectCall { target; attrib }
+  | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
+      let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
+      let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
+      let _ = unify (getty lhs') (getty rhs') in
+      Instr_Load { lhs; rhs; addr = Scalar; attrib }
+  | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
+      let addr = infer_ty [%here] addr in
+      let _ = unify (ptr_typ st) (getty addr) in
+      let mapt = fun_type st (getty addr) (fresh_tvar st ()) in
+      let _ = unify (lookup_var_typ st univ ctx rhs) mapt in
+      let _ =
+        unify
+          (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
+          (bv_type st size)
+      in
+      Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
+  | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
+      let value = infer_ty [%here] value in
+      let _ =
+        unify (getty value)
+        @@ unify
+             (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
+             (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
+      in
+      Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
+  | Instr_Store { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
+    ->
+      let addr = infer_ty [%here] addr in
+      let _ = unify (ptr_typ st) (getty addr) in
+      let mapt = fun_type st (getty addr) ((fresh_tvar st) ()) in
+      let _ = unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx) in
+      let _ = unify (lookup_var_typ st univ ctx rhs) mapt in
+      let value = infer_ty [%here] value in
+      let _ = unify (getty value) (bv_type st size) in
+      Instr_Store
+        { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
+
+let infer_stmt st vc p univ ctx s =
+  try do_infer_stmt st vc p univ ctx s
+  with TypeErr m ->
+    raise
+      (TypeErr
+         (m ^ " " ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
+
+let infer_block st vc p univ ctx (b : Program.bloc) =
+  let _ = infer_phi st vc univ ctx b.phis in
+  Block.map ~phi:Fun.id (infer_stmt st vc p univ ctx) b
+
+let assume_proc_decl st ctx ?(no_constraint = false) (p : Program.proc) =
+  let globs = Var.Decls.values (Procedure.local_decls p) in
+  let formals_in = Procedure.formal_in_params p |> StringMap.values in
+  let formals_out = Procedure.formal_out_params p |> StringMap.values in
+  let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
+  let ctx =
+    Iter.fold
+      (decl_var_typ st ~no_constraint univ)
+      ctx
+      (Iter.append globs @@ Iter.append formals_in formals_out)
+  in
+  ctx

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -24,12 +24,21 @@ module AbsTypingExpr = struct
   let unfix i = match i with E i -> i
 end
 
-(* module TypingExpr = Expr.Make (AbsTypingExpr) *)
+module TypingExpr = Bincaml_util.Recursionscheme.Recursion (struct
+  open Ops.AllOps
+
+  type t = AbsTypingExpr.t
+  type 'e expr = (const, Var.t, unary, binary, intrin, typ, 'e) AbstractExpr.t
+
+  let map_expr = AbstractExpr.map
+  let fix = AbsTypingExpr.fix
+  let unfix = AbsTypingExpr.unfix
+end)
 
 let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
 
-let infer_var univ ctx id =
-  let typ = lookup_var_typ univ ctx id in
+let infer_var st univ ctx id =
+  let typ = lookup_var_typ st univ ctx id in
   (id, typ)
 
 (** Return the generic type scheme for an op. We generalise the type, and hope
@@ -330,15 +339,3 @@ let infer_block st vc p univ ctx (b : Program.bloc) =
   let _ = infer_phi st vc univ ctx b.phis in
   Block.map ~phi:Fun.id (infer_stmt st vc p univ ctx) b
 
-let assume_proc_decl st ctx ?(no_constraint = false) (p : Program.proc) =
-  let globs = Var.Decls.values (Procedure.local_decls p) in
-  let formals_in = Procedure.formal_in_params p |> StringMap.values in
-  let formals_out = Procedure.formal_out_params p |> StringMap.values in
-  let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-  let ctx =
-    Iter.fold
-      (decl_var_typ st ~no_constraint univ)
-      ctx
-      (Iter.append globs @@ Iter.append formals_in formals_out)
-  in
-  ctx

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -8,32 +8,24 @@ open Solve_bv
 
 (** An AbstractExpr.t with [t] used as the type. *)
 module AbsTypingExpr = struct
-  open Ops
-  include AllOps
-  module Var = Var
+  open Ops.AllOps
 
   type var = Var.t
 
-  type t = E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
+  type t =
+    | E of (const, Var.t, unary, binary, intrin, TypeExpr.t, t) AbstractExpr.t
   [@@unboxed] [@@deriving eq, ord]
-
-  type nonrec typ = typ
 
   let top_typ = top_t
   let fix i = E i
   let unfix i = match i with E i -> i
+
+  type 'e expr =
+    (const, Var.t, unary, binary, intrin, TypeExpr.t, 'e) AbstractExpr.t
+
+  let rec cata (alg : 'a expr -> 'a) e =
+    (unfix %> AbstractExpr.map (cata alg) %> alg) e
 end
-
-module TypingExpr = Bincaml_util.Recursionscheme.Recursion (struct
-  open Ops.AllOps
-
-  type t = AbsTypingExpr.t
-  type 'e expr = (const, Var.t, unary, binary, intrin, typ, 'e) AbstractExpr.t
-
-  let map_expr = AbstractExpr.map
-  let fix = AbsTypingExpr.fix
-  let unfix = AbsTypingExpr.unfix
-end)
 
 let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
 
@@ -338,4 +330,3 @@ let infer_stmt st vc p univ ctx s =
 let infer_block st vc p univ ctx (b : Program.bloc) =
   let _ = infer_phi st vc univ ctx b.phis in
   Block.map ~phi:Fun.id (infer_stmt st vc p univ ctx) b
-

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -4,76 +4,70 @@ open Common
 open Abstract_expr
 open Hm_types
 
-module Make (Ctx : TypeExpr.TypeContext) = struct
-  open Unification.Make (Ctx)
-  open Hm_types.Make (Ctx)
-  open Ctx
-  open Ctx.Typ
+(** Naive solver *)
 
-  (** Naive solver *)
+(** Constraints between nat val types. *)
+type dependent_bv_constraints =
+  | Add of { a : TypeExpr.t; b : TypeExpr.t; equ : TypeExpr.t }
+      (** a + b = equ*)
+  | AddConst of { a : TypeExpr.t; b : int; equ : TypeExpr.t }  (** a + b = equ*)
 
-  (** Constraints between nat val types. *)
-  type dependent_bv_constraints =
-    | Add of { a : Ctx.Typ.t; b : Ctx.Typ.t; equ : Ctx.Typ.t }
-        (** a + b = equ*)
-    | AddConst of { a : Ctx.Typ.t; b : int; equ : Ctx.Typ.t }  (** a + b = equ*)
+let show_dependent_bv_constraints = function
+  | Add { a; b; equ } ->
+      Printf.sprintf "%s + %s = %s" (type_to_string a) (type_to_string b)
+        (type_to_string equ)
+  | AddConst { a; b; equ } ->
+      Printf.sprintf "%s + (const %d) = %s" (type_to_string a) b
+        (type_to_string equ)
 
-  let show_dependent_bv_constraints = function
-    | Add { a; b; equ } ->
-        Printf.sprintf "%s + %s = %s" (type_to_string a) (type_to_string b)
-          (type_to_string equ)
-    | AddConst { a; b; equ } ->
-        Printf.sprintf "%s + (const %d) = %s" (type_to_string a) b
-          (type_to_string equ)
+(** Deduce the width if two values of the constraint have inferred widths *)
+let unify_bv_constraint st constr : TypeExpr.t option =
+  let find = TypeExpr.find st and unify = Unification.unify st in
+  let nat_val_type = nat_val_type st in
+  match constr with
+  | Add { a; b; equ } -> (
+      match List.map is_nat_val_type [ find a; find b; find equ ] with
+      | [ Some a_n; Some b_n; Some e_n ] ->
+          (* check constraint  *)
+          if a_n + b_n <> e_n then
+            Unification.type_error st (nat_val_type (a_n + b_n)) equ;
+          Some equ
+      | [ Some a_n; Some b_n; None ] ->
+          Some (unify ~pos:[%here] (nat_val_type (a_n + b_n)) equ)
+      | [ Some a_n; None; Some e_n ] ->
+          Some (unify ~pos:[%here] (nat_val_type (e_n - a_n)) b)
+      | [ None; Some b_n; Some e_n ] ->
+          Some (unify ~pos:[%here] (nat_val_type (e_n - b_n)) a)
+      | _ -> None)
+  | AddConst { a; b; equ } -> (
+      match (is_nat_val_type (find a), is_nat_val_type (find equ)) with
+      | Some a_n, Some e_n ->
+          (* check constraint  *)
+          let e = nat_val_type (a_n + b) in
+          Some (unify ~pos:[%here] e equ)
+      | Some a_n, None -> Some (unify ~pos:[%here] (nat_val_type (a_n + b)) equ)
+      | None, Some e_n -> Some (unify ~pos:[%here] (nat_val_type (e_n - b)) a)
+      | _ -> None)
 
-  (** Deduce the width if two values of the constraint have inferred widths *)
-  let unify_bv_constraint constr : Ctx.Typ.t option =
-    match constr with
-    | Add { a; b; equ } -> (
-        match List.map is_nat_val_type [ find a; find b; find equ ] with
-        | [ Some a_n; Some b_n; Some e_n ] ->
-            (* check constraint  *)
-            if a_n + b_n <> e_n then type_error (nat_val_type (a_n + b_n)) equ;
-            Some equ
-        | [ Some a_n; Some b_n; None ] ->
-            Some (unify ~pos:[%here] (nat_val_type (a_n + b_n)) equ)
-        | [ Some a_n; None; Some e_n ] ->
-            Some (unify ~pos:[%here] (nat_val_type (e_n - a_n)) b)
-        | [ None; Some b_n; Some e_n ] ->
-            Some (unify ~pos:[%here] (nat_val_type (e_n - b_n)) a)
-        | _ -> None)
-    | AddConst { a; b; equ } -> (
-        match (is_nat_val_type (find a), is_nat_val_type (find equ)) with
-        | Some a_n, Some e_n ->
-            (* check constraint  *)
-            let e = nat_val_type (a_n + b) in
-            Some (unify ~pos:[%here] e equ)
-        | Some a_n, None ->
-            Some (unify ~pos:[%here] (nat_val_type (a_n + b)) equ)
-        | None, Some e_n -> Some (unify ~pos:[%here] (nat_val_type (e_n - b)) a)
-        | _ -> None)
-
-  (** Naive solver; loop over constraints and unify until everything is solved.
-  *)
-  let solve_constraints ~max_iters cls =
-    let show = List.to_string ~sep:"\n" show_dependent_bv_constraints in
-    let rec solve tries cs =
-      match cs with
-      | [] -> ()
-      | _ when tries > max_iters ->
-          raise
-            (TypeErr
-               ("Gave up solving bitvec constraints with remaining:\n" ^ show cs))
-      | cs ->
-          let remaining =
-            List.filter_map
-              (fun c ->
-                match unify_bv_constraint c with
-                | Some e -> None
-                | None -> Some c)
-              cs
-          in
-          solve (tries + 1) remaining
-    in
-    solve 0 cls
-end
+(** Naive solver; loop over constraints and unify until everything is solved. *)
+let solve_constraints st ~max_iters cls =
+  let show = List.to_string ~sep:"\n" show_dependent_bv_constraints in
+  let rec solve tries cs =
+    match cs with
+    | [] -> ()
+    | _ when tries > max_iters ->
+        raise
+          (TypeErr
+             ("Gave up solving bitvec constraints with remaining:\n" ^ show cs))
+    | cs ->
+        let remaining =
+          List.filter_map
+            (fun c ->
+              match unify_bv_constraint st c with
+              | Some e -> None
+              | None -> Some c)
+            cs
+        in
+        solve (tries + 1) remaining
+  in
+  solve 0 cls

--- a/lib/lang/hm/state.ml
+++ b/lib/lang/hm/state.ml
@@ -1,6 +1,0 @@
-let x = 2
-
-type 'a state = {
-  unionfind_state : 'a UnionFind.StoreVector.store;
-  hashcons_state : (module Fix.HashCons.SERVICE with type data = 'a);
-}

--- a/lib/lang/hm/state.ml
+++ b/lib/lang/hm/state.ml
@@ -1,0 +1,6 @@
+let x = 2
+
+type 'a state = {
+  unionfind_state : 'a UnionFind.StoreVector.store;
+  hashcons_state : (module Fix.HashCons.SERVICE with type data = 'a);
+}

--- a/lib/lang/hm/typeExpr.ml
+++ b/lib/lang/hm/typeExpr.ml
@@ -50,10 +50,7 @@ type t = nt UnionFind.elem Fix.HashCons.cell
 and nt = T of t ATyp.expr  (** TODO: what is `nt` mean? *)
 
 let equal = Fix.HashCons.equal
-
-(** TODO: is this the right implementation? *)
 let compare = Fix.HashCons.compare
-
 let map_expr = ATyp.map_expr
 
 (** Hash cons the data underlying the UF reference so we can construct the type

--- a/lib/lang/hm/typeExpr.ml
+++ b/lib/lang/hm/typeExpr.ml
@@ -77,7 +77,9 @@ module State = struct
             expression for the given {!nt}. *)
     gen : ID.generator;  (** Type name generator. *)
   }
-  (** Union find and hash-consing state for recording type relations. *)
+  (** Union find and hash-consing state for recording type relations.
+
+      @canonical TypeExpr.state *)
 
   (** Create a new union find and hash-cons state.
 

--- a/lib/lang/hm/typeExpr.ml
+++ b/lib/lang/hm/typeExpr.ml
@@ -44,60 +44,86 @@ module ATyp = struct
     | TypeConstr (l, t) -> Hash.pair (Hash.list he) Hash.string (l, t)
 end
 
-(** Create the union find and hash-consing structure for recording type
-    relations. This must be done each time we want to perform inference in an
-    independent environment, in order to construct a fresh hash-consing and
-    union-find state. *)
-module MakeFresh () = struct
-  module Typ = struct
-    include ATyp
+type t = nt UnionFind.elem Fix.HashCons.cell
+(** Union find and hash-consing type for representing type expressions. *)
 
-    type t = nt UnionFind.elem Fix.HashCons.cell
-    and nt = T of t expr
+and nt = T of t ATyp.expr  (** TODO: what is `nt` mean? *)
 
-    module Hashed = struct
-      type t = nt UnionFind.elem
-      (* we hash cons the data underlying the uf reference so we can construct the
-       type and get the UF reference *)
+let equal = Fix.HashCons.equal
 
-      let hash (e : t) : int =
-        e |> UnionFind.get |> function T e -> ATyp.hash Fix.HashCons.hash e
+(** TODO: is this the right implementation? *)
+let compare = Fix.HashCons.compare
 
-      let equal (i : t) (j : t) : bool =
-        match (UnionFind.get i, UnionFind.get j) with
-        | T i, T j -> ATyp.equal_expr Fix.HashCons.equal i j
-    end
+let map_expr = ATyp.map_expr
 
-    module H = Fix.HashCons.ForHashedType (Hashed)
+(** Hash cons the data underlying the UF reference so we can construct the type
+    and get the UF reference. *)
+module Hash_inner = struct
+  type t = nt UnionFind.elem
+  (** This is the type within the {!Fix.HashCons.cell}. *)
 
-    let unfix : t -> t expr =
-      Fix.HashCons.data %> UnionFind.find %> UnionFind.get %> function
-      | T e -> e
+  let hash (e : t) : int =
+    e |> UnionFind.get |> function T e -> ATyp.hash Fix.HashCons.hash e
 
-    let fix (e : t expr) : t = H.make (UnionFind.make (T e))
-
-    let union (a : t) (b : t) : t =
-      H.make @@ UnionFind.union (Fix.HashCons.data a) (Fix.HashCons.data b)
-
-    (** dubious; has invariant that H.make returns same ref as find ;
-        - should be true if we don't reassign refs but *)
-    let find e = Fix.HashCons.data e |> UnionFind.find |> H.make
-
-    let merge f (a : t) (b : t) : t =
-      H.make
-      @@ UnionFind.merge
-           (fun (T a) (T b) -> T (f a b))
-           (Fix.HashCons.data a) (Fix.HashCons.data b)
-
-    let compare a b = Fix.HashCons.compare a b
-    let equal a b = Fix.HashCons.equal a b
-  end
-
-  (** type name generator *)
-  let gen = ID.make_gen ()
-
-  module Rec = Bincaml_util.Recursionscheme.Recursion (Typ)
+  let equal (i : t) (j : t) : bool =
+    match (UnionFind.get i, UnionFind.get j) with
+    | T i, T j -> ATyp.equal_expr Fix.HashCons.equal i j
 end
 
-module type TypeContext = module type of MakeFresh ()
-(** Type of mutable type context union find *)
+type state = {
+  hcons : Hash_inner.t -> t;
+      (** Construct (or re-obtain) a hash-consed union-find-supporting type
+          expression for the given {!nt}. *)
+  gen : ID.generator;  (** Type name generator. *)
+}
+(** Union find and hash-consing state for recording type relations. *)
+
+(** Create a new union find and hash-cons state.
+
+    This must be done each time we want to perform inference in an independent
+    environment, in order to construct a fresh hash-consing and union-find
+    state. *)
+let create_state () =
+  let module H = Fix.HashCons.ForHashedType (Hash_inner) in
+  { hcons = (fun e -> H.make e); gen = ID.make_gen () }
+
+let unfix : t -> t ATyp.expr =
+  Fix.HashCons.data %> UnionFind.find %> UnionFind.get %> function T e -> e
+
+let fix st (e : t ATyp.expr) : t = st.hcons (UnionFind.make (T e))
+
+let union st (a : t) (b : t) : t =
+  st.hcons @@ UnionFind.union (Fix.HashCons.data a) (Fix.HashCons.data b)
+
+(** dubious; has invariant that H.make returns same ref as find ;
+    - should be true if we don't reassign refs but *)
+let find st e = Fix.HashCons.data e |> UnionFind.find |> st.hcons
+
+let merge st f (a : t) (b : t) : t =
+  st.hcons
+  @@ UnionFind.merge
+       (fun (T a) (T b) -> T (f a b))
+       (Fix.HashCons.data a) (Fix.HashCons.data b)
+
+(** Fold an algebra ['a expr -> 'a] through the type expression, from leaves to
+    nodes, and returns the final ['a].
+
+    This is manually implemented because it only uses {!unfix}, so it does not
+    need {!state}. Whereas, recursion scheme functions which use [fix] would
+    need {!state}. *)
+let rec cata (alg : 'a ATyp.expr -> 'a) e =
+  (unfix %> ATyp.map_expr (cata alg) %> alg) e
+
+(** Full recursion-scheme bundle for {!t}. If you only need [cata], also see the
+    separate {!cata}. *)
+module Rec (S : sig
+  val state : state
+end) =
+Bincaml_util.Recursionscheme.Recursion (struct
+  type 'e expr = 'e ATyp.expr
+  type nonrec t = t
+
+  let fix = fix S.state
+  let unfix = unfix
+  let map_expr = ATyp.map_expr
+end)

--- a/lib/lang/hm/typeExpr.ml
+++ b/lib/lang/hm/typeExpr.ml
@@ -70,22 +70,27 @@ module Hash_inner = struct
     | T i, T j -> ATyp.equal_expr Fix.HashCons.equal i j
 end
 
-type state = {
-  hcons : Hash_inner.t -> t;
-      (** Construct (or re-obtain) a hash-consed union-find-supporting type
-          expression for the given {!nt}. *)
-  gen : ID.generator;  (** Type name generator. *)
-}
-(** Union find and hash-consing state for recording type relations. *)
+module State = struct
+  type state = {
+    hcons : Hash_inner.t -> t;
+        (** Construct (or re-obtain) a hash-consed union-find-supporting type
+            expression for the given {!nt}. *)
+    gen : ID.generator;  (** Type name generator. *)
+  }
+  (** Union find and hash-consing state for recording type relations. *)
 
-(** Create a new union find and hash-cons state.
+  (** Create a new union find and hash-cons state.
 
-    This must be done each time we want to perform inference in an independent
-    environment, in order to construct a fresh hash-consing and union-find
-    state. *)
-let create_state () =
-  let module H = Fix.HashCons.ForHashedType (Hash_inner) in
-  { hcons = (fun e -> H.make e); gen = ID.make_gen () }
+      This must be done each time we want to perform inference in an independent
+      environment, in order to construct a fresh hash-consing and union-find
+      state. *)
+  let create_state () =
+    let module H = Fix.HashCons.ForHashedType (Hash_inner) in
+    { hcons = (fun e -> H.make e); gen = ID.make_gen () }
+end
+
+include State
+(** @inline *)
 
 let unfix : t -> t ATyp.expr =
   Fix.HashCons.data %> UnionFind.find %> UnionFind.get %> function T e -> e

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -3,108 +3,102 @@
 open Common
 open Abstract_expr
 
-module Make (T : TypeExpr.TypeContext) = struct
-  open Hm_types.Make (T)
-  (* XXX: todo *)
+let type_error st a b =
+  let a, b = TypeExpr.(find st a, find st b) in
+  raise
+    (Hm_types.TypeErr
+       ("type_error: " ^ Hm_types.type_to_string a ^ " <> "
+      ^ Hm_types.type_to_string b))
 
-  open T
-  open T.Typ
+let recursion_error st a b =
+  let b = TypeExpr.find st b in
+  raise
+    (Hm_types.TypeErr
+       ("recursive: tvar " ^ ID.to_string a ^ " occurs in "
+      ^ Hm_types.type_to_string b))
 
-  let type_error a b =
-    let a = find a in
-    let b = find b in
-    raise
-      (Hm_types.TypeErr
-         ("type_error: " ^ type_to_string a ^ " <> " ^ type_to_string b))
+(** Check for type recursion: recursion is failure. *)
+let occurs_in a b =
+  let check = function
+    | TypeExpr.ATyp.Var t -> TypeExpr.equal_tvar t a
+    | TypeConstr (ls, _) -> List.exists Fun.id ls
+  in
+  TypeExpr.cata check b
 
-  let recursion_error a b =
-    let b = find b in
-    raise
-      (Hm_types.TypeErr
-         ("recursive: tvar " ^ ID.to_string a ^ " occurs in " ^ type_to_string b))
+(** Type unification.*)
+let rec unify st ?(pos = Lexing.dummy_pos) t t' =
+  let fix, find = (TypeExpr.fix st, TypeExpr.find st) in
 
-  (** Check for type recursion: recursion is failure. *)
-  let occurs_in a b =
-    let check = function
-      | Var t -> TypeExpr.equal_tvar t a
-      | TypeConstr (ls, _) -> List.exists Fun.id ls
-    in
-    Rec.cata check b
+  Logs.debug (fun m ->
+      m "%s"
+        ("unify: " ^ Hm_types.plpos pos ^ " "
+        ^ Hm_types.type_to_string (find t)
+        ^ " with "
+        ^ Hm_types.type_to_string (find t')));
+  match TypeExpr.(map_expr unfix @@ unfix t, map_expr unfix @@ unfix t') with
+  | TypeConstr ([], "nothing"), _ -> t
+  | _, TypeConstr ([], "nothing") -> t'
+  | Var x, Var y -> TypeExpr.union st t t'
+  | Var x, _ when occurs_in x t' -> recursion_error st x t'
+  | Var _, TypeConstr _ -> TypeExpr.merge st (fun a b -> b) t t'
+  | _, Var x -> unify st ~pos:[%here] t' t
+  | TypeConstr (ars, n), TypeConstr (ars', n') when not (String.equal n n') ->
+      type_error st t t'
+  | TypeConstr (ars, n), TypeConstr (ars', n')
+    when List.length ars <> List.length ars' ->
+      type_error st t t'
+  | ( TypeConstr ([ (Var v as vr) ], "bv"),
+      TypeConstr ([ (TypeConstr ([], a) as cst) ], "bv") )
+  | ( TypeConstr ([ (TypeConstr ([], a) as cst) ], "bv"),
+      TypeConstr ([ (Var v as vr) ], "bv") ) ->
+      (* prioritise bitvec consts *)
+      let v = TypeExpr.merge st (fun _ c -> c) (fix vr) (fix cst) in
+      fix @@ TypeConstr ([ v ], "bv")
+  | TypeConstr (ars, n), TypeConstr (ars', n') ->
+      let args =
+        List.combine ars ars'
+        |> List.map (fun (a, b) -> unify st ~pos:[%here] (fix a) (fix b))
+      in
+      TypeExpr.merge st (fun a b -> TypeConstr (args, n)) t t'
 
-  (** Type unification.*)
-  let rec unify ?(pos = Lexing.dummy_pos) t t' =
-    Logs.debug (fun m ->
-        m "%s"
-          ("unify: " ^ plpos pos ^ " "
-          ^ type_to_string (find t)
-          ^ " with "
-          ^ type_to_string (find t')));
-    match (map_expr unfix @@ Typ.unfix t, map_expr unfix @@ Typ.unfix t') with
-    | TypeConstr ([], "nothing"), _ -> t
-    | _, TypeConstr ([], "nothing") -> t'
-    | Var x, Var y -> Typ.union t t'
-    | Var x, _ when occurs_in x t' -> recursion_error x t'
-    | Var _, TypeConstr _ -> merge (fun a b -> b) t t'
-    | _, Var x -> unify ~pos:[%here] t' t
-    | TypeConstr (ars, n), TypeConstr (ars', n') when not (String.equal n n') ->
-        type_error t t'
-    | TypeConstr (ars, n), TypeConstr (ars', n')
-      when List.length ars <> List.length ars' ->
-        type_error t t'
-    | ( TypeConstr ([ (Var v as vr) ], "bv"),
-        TypeConstr ([ (TypeConstr ([], a) as cst) ], "bv") )
-    | ( TypeConstr ([ (TypeConstr ([], a) as cst) ], "bv"),
-        TypeConstr ([ (Var v as vr) ], "bv") ) ->
-        (* prioritise bitvec consts *)
-        let v = merge (fun _ c -> c) (fix vr) (fix cst) in
-        fix @@ TypeConstr ([ v ], "bv")
-    | TypeConstr (ars, n), TypeConstr (ars', n') ->
-        let args =
-          List.combine ars ars'
-          |> List.map (fun (a, b) -> unify ~pos:[%here] (fix a) (fix b))
-        in
-        merge (fun a b -> TypeConstr (args, n)) t t'
+(** instantiate typescheme for a single type-annotated variable *)
+let inst_annot_v st ?(no_constraint = false) v =
+  let ty =
+    match (no_constraint, Var.typ v) with
+    | true, _ | _, Nothing ->
+        TypeExpr.fix st @@ Var (st.gen.fresh ~name:(Var.name v) ())
+    | _, o -> Hm_types.ty_of_basil st o
+  in
+  ty
 
-  (** instantiate typescheme for a single type-annotated variable *)
-  let inst_annot_v ?(no_constraint = false) v =
-    let ty =
-      match Var.typ v with
-      | _ when no_constraint -> fix @@ Var (gen.fresh ~name:(Var.name v) ())
-      | Nothing -> fix @@ Var (gen.fresh ~name:(Var.name v) ())
-      | o -> ty_of_basil o
-    in
-    ty
+(** lookup var and add unify with its type annotation *)
+let lookup_var_typ st univ ?(no_constraint = false) c v =
+  let vt = inst_annot_v st v in
+  let a =
+    let v = TypeExpr.V.of_var univ v in
+    TypeExpr.TCtx.find_opt v c |> function
+    | Some v -> v
+    | None -> failwith ("var not found: " ^ TypeExpr.V.to_string v)
+  in
+  match a with Hm_types.Forall (_, ty) -> TypeExpr.union st ty vt
 
-  (** lookup var and add unify with its type annotation *)
-  let lookup_var_typ univ ?(no_constraint = false) c v =
-    let vt = inst_annot_v v in
-    let a =
-      let v = TypeExpr.V.of_var univ v in
-      TypeExpr.TCtx.find_opt v c |> function
-      | Some v -> v
-      | None -> failwith ("var not found: " ^ TypeExpr.V.to_string v)
-    in
-    let tt = match a with Forall (_, ty) -> union ty vt in
-    tt
+(** declare type with name in type scheme *)
+let decl_type st ctx name vt =
+  let tvar = TypeExpr.V.create Hm_types.types_universe name in
+  TypeExpr.TCtx.update tvar
+    (function
+      | Some (Hm_types.Forall ([], t)) -> Some (Forall ([], unify st vt t))
+      | None -> Some (Forall ([], vt))
+      | _ -> failwith "unk")
+    ctx
 
-  (** declare type with name in type scheme *)
-  let decl_type ctx name vt =
-    let tvar = TypeExpr.V.create types_universe name in
-    TypeExpr.TCtx.update tvar
-      (function
-        | Some (Forall ([], t)) -> Some (Forall ([], unify vt t))
-        | None -> Some (Forall ([], vt))
-        | _ -> failwith "unk")
-      ctx
-
-  (** declare var with type in type scheme *)
-  let decl_var_typ univ ?(no_constraint = false) c v =
-    let vvar = TypeExpr.V.of_var univ v in
-    let vt = inst_annot_v v in
-    TypeExpr.TCtx.update vvar
-      (function
-        | Some (Forall ([], t)) -> Some (Forall ([], unify vt t))
-        | None -> Some (Forall ([], vt))
-        | _ -> failwith "unk")
-      c
-end
+(** declare var with type in type scheme *)
+let decl_var_typ st univ ?(no_constraint = false) c v =
+  let vvar = TypeExpr.V.of_var univ v in
+  let vt = inst_annot_v st v in
+  TypeExpr.TCtx.update vvar
+    (function
+      | Some (Hm_types.Forall ([], t)) -> Some (Forall ([], unify st vt t))
+      | None -> Some (Forall ([], vt))
+      | _ -> failwith "unk")
+    c


### PR DESCRIPTION
This adds a new `module State` to the typeExpr.ml module which contains the hashcons state as a stored closure. Downstream functions which need to call hashcons's `fix` now take a `st` parameter of `State.t` type. The state is internally mutable, so it does not need to be threaded through like a state monad - it just needs the reference to be passed.

This is a very mechanical change, and I didn't think very much about whether `st` could be combined with other things or done more carefully.

The diff is big because a lot of things are de-dented since they are no longer in functors, but the actual change is mostly simple I think.

There is a new `smart_constructors` function (and module) which can be used to get a set of smart constructors with the state pre-applied, e.g.
```ocaml
let scheme_of_op st ~visit_constraint (gen : ID.generator)
    (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
  let open (val Hm_types.smart_constructors st) in
  let fv () = TypeExpr.fix st @@ Var (gen.fresh ~name:"a" ()) in
  match o with
  | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
```