### PR TITLE
aslp: merge `$mem` functionality into `add_aarch64_global_declarations` 

### DIFF
--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -142,21 +142,24 @@ let transform_procedure proc =
 
 (** Adds architectural variable declarations to the given program. By default,
     includes only those variables which are used. *)
-let add_aarch64_global_declarations ?(add_all = false) prog =
-  let include_var =
-    if add_all then Fun.const true
+let add_aarch64_global_declarations ?(include_unused = false) prog =
+  let include_predicate =
+    if include_unused then Fun.const true
     else
       Fun.flip VarSet.mem
-        (Program.referenced_vars_of_prog prog |> Iter.to_set (module VarSet))
+        (Program.referenced_vars_of_prog prog |> VarSet.of_iter)
   in
 
-  Lazy.force Aslp_lexpr.global_vars
-  |> List.to_iter |> Iter.filter include_var
+  Lazy.force Aslp_lexpr.globals
+  |> List.to_iter
+  |> Iter.filter (Aslp_lexpr.to_var %> include_predicate)
+  |> Iter.map (Fun.tap (Aslp_lexpr.check_decl_type prog))
   |> Iter.fold
-       (fun prog var ->
+       (fun prog v ->
+         let binding = Aslp_lexpr.to_var v in
          let attrib = Attrib.empty and classification = None in
          Program.add_decl prog
-           (Program.Variable { binding = var; attrib; classification }))
+           (Program.Variable { binding; attrib; classification }))
        prog
 
 (** Transforms the {!Lang.Stmt.Intrinsic.Aarch64Eval} intrinsics of all
@@ -166,17 +169,6 @@ let add_aarch64_global_declarations ?(add_all = false) prog =
     memory, if used and not already present. Finally, re-computes the "modifies"
     sets of the procedures. *)
 let transform_program prog =
-  (match Program.get_decl_by_name (Aslp_lexpr.name Memory) prog with
-  | Some (Variable { binding }) ->
-      if not (Types.equal (Var.typ binding) (Aslp_lexpr.typ Memory)) then
-        Logs.warn (fun m ->
-            m
-              "Memory declared with unexpected type; lifter may produce \
-               wrongly-typed or incorrect code.")
-  | Some _ ->
-      failwith (Aslp_lexpr.name Memory ^ " already declared as non-variable")
-  | None -> () (* will be added by add_aarch64_global_declarations *));
-
   prog
   |> Program.map_procedures (fun _ -> transform_procedure)
   |> add_aarch64_global_declarations

--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -136,8 +136,7 @@ let transform_block (module I : Bincaml_ibi.IBI) ~proc bid =
 (** Transforms the {!Lang.Stmt.Intrinsic.Aarch64Eval} intrinsics of all blocks
     within the given procedure. *)
 let transform_procedure proc =
-  let memory () = Aslp_lexpr.to_var Memory in
-  let module I = (val Bincaml_ibi.from_bincaml_procedure ~memory proc) in
+  let module I = (val Bincaml_ibi.from_bincaml_procedure proc) in
   Procedure.iter_blocks proc
   |> Iter.fold (fun proc (bid, _) -> transform_block (module I) ~proc bid) proc
 

--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -73,30 +73,6 @@ let stmt_of_aarch64_intrin ?error :
   let args = Expr.BasilExpr.[ bvconst opcode; bvconst address ] in
   Stmt.Instr_IntrinCall { attrib; lhs = []; name = Aarch64Eval; args }
 
-(** Returns the Bincaml global variable representing heap memory, declaring it
-    if it does not exist. *)
-let aarch64_mem_of_prog prog =
-  let mem_name = "$mem" in
-  let mem_type = Types.(Map (Bitvector 64, Bitvector 8)) in
-  Program.get_decl_by_name "$mem" prog |> function
-  | Some (Variable { binding }) ->
-      if not (Types.equal (Var.typ binding) mem_type) then
-        Logs.warn (fun m ->
-            m
-              "Memory declared with unexpected type; lifter may not produce \
-               well-typed or correct code.");
-      (prog, binding)
-  | None ->
-      let mem = Var.create mem_name ~scope:Var.GlobalVarShared mem_type in
-
-      let prog =
-        let attrib = Attrib.empty and classification = None in
-        Program.add_decl prog
-          (Program.Variable { binding = mem; attrib; classification })
-      in
-      (prog, mem)
-  | _ -> failwith @@ mem_name ^ " already declared as non-variable"
-
 (** {1 Main Bincaml IR transformation functions} *)
 
 (** Inserts one {!Aslp_state.aslp_diamond} into the given procedure, including
@@ -159,8 +135,8 @@ let transform_block (module I : Bincaml_ibi.IBI) ~proc bid =
 
 (** Transforms the {!Lang.Stmt.Intrinsic.Aarch64Eval} intrinsics of all blocks
     within the given procedure. *)
-let transform_procedure ~memory proc =
-  let memory = Fun.const memory in
+let transform_procedure proc =
+  let memory () = Aslp_lexpr.to_var Memory in
   let module I = (val Bincaml_ibi.from_bincaml_procedure ~memory proc) in
   Procedure.iter_blocks proc
   |> Iter.fold (fun proc (bid, _) -> transform_block (module I) ~proc bid) proc
@@ -187,12 +163,23 @@ let add_aarch64_global_declarations ?(add_all = false) prog =
 (** Transforms the {!Lang.Stmt.Intrinsic.Aarch64Eval} intrinsics of all
     procedures within the given program.
 
-    Also inserts global variable declarations for the architectural variables,
-    if not already present. *)
+    Inserts global variable declarations for the architectural variables and
+    memory, if used and not already present. Finally, re-computes the "modifies"
+    sets of the procedures. *)
 let transform_program prog =
-  let prog, memory = aarch64_mem_of_prog prog in
+  (match Program.get_decl_by_name (Aslp_lexpr.name Memory) prog with
+  | Some (Variable { binding }) ->
+      if not (Types.equal (Var.typ binding) (Aslp_lexpr.typ Memory)) then
+        Logs.warn (fun m ->
+            m
+              "Memory declared with unexpected type; lifter may produce \
+               wrongly-typed or incorrect code.")
+  | Some _ ->
+      failwith (Aslp_lexpr.name Memory ^ " already declared as non-variable")
+  | None -> () (* will be added by add_aarch64_global_declarations *));
+
   prog
-  |> Program.map_procedures (fun _ -> transform_procedure ~memory)
+  |> Program.map_procedures (fun _ -> transform_procedure)
   |> add_aarch64_global_declarations
   |> Spec_modifies.set_modsets ~add_only:false
 

--- a/lib/transforms/aslp/aslp_lexpr.ml
+++ b/lib/transforms/aslp/aslp_lexpr.ml
@@ -8,6 +8,7 @@ open Common
     {!Lang.Common.Var.t}. *)
 type t =
   | Local of string * Types.t
+  | Memory
   | PC
   | R of int option
       (** A 64-bit ordinary register. [None] is used to represent the virtual
@@ -42,6 +43,7 @@ let typ (x : t) =
   let bv = Types.bv in
   match x with
   | Local (_, t) -> t
+  | Memory -> Types.Map (Types.Bitvector 64, Types.Bitvector 8)
   | R (Some _) -> bv 64
   | Z (Some _) -> bv 128
   | PC -> bv 64
@@ -58,30 +60,35 @@ let typ (x : t) =
   | ExclusiveLocal -> Types.Boolean
   | R None | Z None -> failwith "typeof_lexpr: array lexpr has no bincaml type"
 
-let name = function
-  | Local (v, _) -> v
-  | SP_EL0 -> "SP"
-  | R (Some n) -> Printf.sprintf "R%d" n
-  | Z (Some n) -> Printf.sprintf "Z%d" n
-  | R None | Z None -> failwith "name_of_lexpr: array lexpr has no bincaml name"
-  | v -> show v
-
 let scope = function
   | Local _ -> Var.LocalVar
   | BranchTaken | BTypeCompatible | BTypeNext -> LocalVar
+  | Memory -> GlobalVarShared
   | _ -> GlobalVar
 
-let to_var x =
-  let ty = typ x and name = name x and scope = scope x in
-  let name = match scope with GlobalVar -> "$" ^ name | _ -> name in
-  Var.create ~scope name ty
+(** Includes sigil for global variables. *)
+let name lexpr =
+  (match lexpr with
+    | Local (v, _) -> v
+    | Memory -> "mem"
+    | SP_EL0 -> "SP"
+    | R (Some n) -> Printf.sprintf "R%d" n
+    | Z (Some n) -> Printf.sprintf "Z%d" n
+    | R None | Z None ->
+        failwith "name_of_lexpr: array lexpr has no bincaml name"
+    | v -> show v)
+  |>
+  match scope lexpr with
+  | GlobalVarShared | GlobalVar | GlobalConst -> ( ^ ) "$"
+  | LocalVar | LocalConst -> Fun.id
 
+let to_var x = Var.create ~scope:(scope x) (name x) (typ x)
 let pc_var = to_var PC
 let branchtaken_var = to_var BranchTaken
 
 let predefined =
   lazy
-    ([ PC; SP_EL0 ]
+    ([ Memory; PC; SP_EL0 ]
     @ List.init 31 (fun i -> R (Some i))
     @ List.init 31 (fun i -> Z (Some i))
     @ [ FPSR; FPCR; PSTATE_N; PSTATE_Z; PSTATE_C; PSTATE_V ]

--- a/lib/transforms/aslp/aslp_lexpr.ml
+++ b/lib/transforms/aslp/aslp_lexpr.ml
@@ -60,11 +60,15 @@ let typ (x : t) =
   | ExclusiveLocal -> Types.Boolean
   | R None | Z None -> failwith "typeof_lexpr: array lexpr has no bincaml type"
 
-let scope = function
+let scope : t -> Var.scope = function
   | Local _ -> Var.LocalVar
   | BranchTaken | BTypeCompatible | BTypeNext -> LocalVar
   | Memory -> GlobalVarShared
   | _ -> GlobalVar
+
+let is_global = function
+  | Var.GlobalVarShared | GlobalVar | GlobalConst -> true
+  | LocalVar | LocalConst -> false
 
 (** Includes sigil for global variables. *)
 let name lexpr =
@@ -77,16 +81,13 @@ let name lexpr =
     | R None | Z None ->
         failwith "name_of_lexpr: array lexpr has no bincaml name"
     | v -> show v)
-  |>
-  match scope lexpr with
-  | GlobalVarShared | GlobalVar | GlobalConst -> ( ^ ) "$"
-  | LocalVar | LocalConst -> Fun.id
+  |> if is_global (scope lexpr) then ( ^ ) "$" else Fun.id
 
 let to_var x = Var.create ~scope:(scope x) (name x) (typ x)
 let pc_var = to_var PC
 let branchtaken_var = to_var BranchTaken
 
-let predefined =
+let predefined : t list Lazy.t =
   lazy
     ([ Memory; PC; SP_EL0 ]
     @ List.init 31 (fun i -> R (Some i))
@@ -98,5 +99,20 @@ let predefined =
       ]
     @ [ BTypeCompatible; BranchTaken; BTypeNext; ExclusiveLocal ])
 
-let global_vars =
-  predefined |> Lazy.map (List.map to_var %> List.filter Var.is_global)
+let globals : t list Lazy.t =
+  predefined |> Lazy.map (List.filter (scope %> is_global))
+
+(** Checks that if the given {!Aslp_lexpr.t} global has already been declared in
+    the program, that it has the same type as {!Aslp_lexpr.typ}. *)
+let check_decl_type prog var =
+  match Program.get_decl_by_name (name var) prog with
+  | Some (Variable { binding }) when Types.equal (Var.typ binding) (typ var) ->
+      ()
+  | Some (Variable { binding }) ->
+      Logs.warn (fun m ->
+          m
+            "Aslp variable %a is already declared but has unexpected type: %a. \
+             Lifter output may be incorrect."
+            pp var Var.pp binding)
+  | Some _ -> failwith (name var ^ " already declared as non-variable")
+  | None -> () (* var is not declared yet. this is fine. *)

--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -21,15 +21,13 @@ module type IBI = sig
 end
 
 (** Builds a new {!IBI} with the given initial generator state. *)
-let from_generator ?(memory = fun () -> failwith "bincaml_memory_var undefined")
-    generator : (module IBI) =
+let from_generator generator : (module IBI) =
   (module Make (struct
     let initial_lifter_state = Aslp_state.empty_lifter_state ~generator ()
-    let bincaml_memory_var = memory
   end))
 
 (** Builds a new {!IBI} where the ID generators are derived from the given
     procedure. *)
-let from_bincaml_procedure ?memory proc : (module IBI) =
+let from_bincaml_procedure proc : (module IBI) =
   let local_ids = Procedure.local_ids proc in
-  from_generator ?memory (Aslp_state.aslp_ids_from_generators ~local_ids)
+  from_generator (Aslp_state.aslp_ids_from_generators ~local_ids)

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -4,7 +4,6 @@ open Common
 (** Makes a concrete module which implements {!Bincaml_ibi.IBI}. *)
 module Make (S : sig
   val initial_lifter_state : Aslp_state.lifter_state
-  val bincaml_memory_var : unit -> Var.t
 end) =
 struct
   (** {2 Type definitions} *)
@@ -304,7 +303,7 @@ struct
    fun size addr _ _acctype value ->
     let size = 8 * Z.to_int size in
     let addr = Stmt.Addr { addr; size; endian = `Little }
-    and mem = S.bincaml_memory_var () in
+    and mem = Aslp_lexpr.to_var Memory in
     bincaml_internal_emit
       (Stmt.Instr_Store
          { attrib = Attrib.empty; lhs = mem; rhs = mem; value; addr })
@@ -316,7 +315,7 @@ struct
    fun size addr _ _acctype ->
     let size = 8 * Z.to_int size in
     let addr = Stmt.Addr { addr; size; endian = `Little }
-    and mem = S.bincaml_memory_var () in
+    and mem = Aslp_lexpr.to_var Memory in
     (* NOTE: avoids `bincaml_local_var` so these variables do not clash with ASLp-declared variables. *)
     let name = !bincaml_lifter_state.generator.local_id () in
     let lhs = Var.create name (Types.bv size) in


### PR DESCRIPTION
This makes it use the same global variable declaration logic as the normal registers. This simplifies the code a bit and it avoids inserting memory if none of the lifted instructions reference it.

After this change, we can remove `bincaml_memory_var` from the IBI parameters entirely. 
