### PR TITLE
`nix develop`-based fast path in CI

### DIFF
--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -66,3 +66,6 @@ jobs:
     if: >
       needs.build_test.result == 'success' || needs.build_test_slower.result == 'success'
 
+    steps:
+      - run: true
+

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -53,7 +53,7 @@ jobs:
       - run: opam repository --all add pac https://github.com/uq-pac/opam-repository.git
       - run: opam install . --deps-only --with-test
       - run: echo LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib" >> "$GITHUB_ENV"
-        if: ${{ matrix.os }} == "macos-latest"
+        if: ${{ matrix.os }} == 'macos-latest'
       - run: opam lint
       - run: opam exec -- dune build @fmt --display=quiet
       - run: opam exec -- dune build --ignore-promoted-rules --profile=release
@@ -64,5 +64,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build_test, build_test_slower ]
     if: >
-      needs.build_test.result == "success" || needs.build_test_slower.result == "success"
+      needs.build_test.result == 'success' || needs.build_test_slower.result == 'success'
 

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -10,12 +10,17 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: nix develop .#ci --ignore-env --keep-env-var CI --command bash -e {0}
+
 jobs:
   build_test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: nix develop .#ci --ignore-env --keep-env-var CI --command bash -e {0}
 
     steps:
       - uses: actions/checkout@v5
@@ -23,17 +28,36 @@ jobs:
           submodules: true
 
       - uses: cachix/install-nix-action@v31
-      - name: Preparing Nix shell
-        run: true
+      - run: echo "Preparing Nix shell"
 
       - run: dune build --profile=release
       - run: dune runtest --force
 
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: cachix/install-nix-action@v31
+      - run: echo "Preparing Nix shell"
+
+      - run: dune build @fmt --display=quiet
+        if: "!cancelled()"
+      - run: dune build '@treesit'
+        if: "!cancelled()"
+
   build_test_slower:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [ build_test ]
-    if: "! ( cancelled() || success() )"
+    needs: [ build_test, format ]
+    if: "! ( cancelled() || success() ) || github.ref == 'refs/heads/main'"
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@v6
@@ -55,9 +79,26 @@ jobs:
 
   at_least_one_success:
     runs-on: ubuntu-latest
-    needs: [ build_test, build_test_slower ]
+    needs: [ build_test_slower ]
     if: "!cancelled()"
+
+    defaults:
+      run:
+        shell: bash
+
     steps:
-      - run: ${{ needs.build_test.result == 'success' || needs.build_test_slower.result == 'success' }}
+      - run: ${{ needs.build_test_slower.result == 'success' || needs.build_test_slower.result == 'skipped' }}
         name: "Check that at least one build & test job succeeded"
 
+  docs-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: cachix/install-nix-action@v31
+      - run: echo "Preparing Nix shell"
+
+      - run: odoc_driver bincaml # TODO: fixme. need to register packages somehow?

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: nix develop .#ci --ignore-env --keep-env-var CI --command bash {0}
+        shell: nix develop .#ci --ignore-env --keep-env-var CI --command bash -e {0}
 
     steps:
       - uses: actions/checkout@v5
@@ -23,7 +23,9 @@ jobs:
           submodules: true
 
       - uses: cachix/install-nix-action@v31
-      - run: echo "Preparing Nix shell"
+      - name: Preparing Nix shell
+        run: true
+
       - run: dune build --profile=release
       - run: dune runtest --force
 
@@ -54,8 +56,8 @@ jobs:
   at_least_one_success:
     runs-on: ubuntu-latest
     needs: [ build_test, build_test_slower ]
-    if: >
-      !cancelled() && ( needs.build_test.result == 'success' || needs.build_test_slower.result == 'success' )
+    if: "!cancelled()"
     steps:
-      - run: true
+      - run: ${{ needs.build_test.result == 'success' || needs.build_test_slower.result == 'success' }}
+        name: "Check that at least one build & test job succeeded"
 

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -53,7 +53,7 @@ jobs:
       - run: opam repository --all add pac https://github.com/uq-pac/opam-repository.git
       - run: opam install . --deps-only --with-test
       - run: echo LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib" >> "$GITHUB_ENV"
-        if: ${{ matrix.os }} == 'macos-latest'
+        if: matrix.os == 'macos-latest'
       - run: opam lint
       - run: opam exec -- dune build @fmt --display=quiet
       - run: opam exec -- dune build --ignore-promoted-rules --profile=release

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -55,8 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build_test, build_test_slower ]
     if: >
-      needs.build_test.result == 'success' || needs.build_test_slower.result == 'success'
-
+      !cancelled() && ( needs.build_test.result == 'success' || needs.build_test_slower.result == 'success' )
     steps:
       - run: true
 

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: exec nix develop .#ci --ignore-env --keep-env-var CI --command {0}
+        shell: nix develop .#ci --ignore-env --keep-env-var CI --command {0}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -12,14 +12,7 @@ permissions: read-all
 
 jobs:
   build_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: nix develop .#ci --ignore-env --keep-env-var CI --command {0}
@@ -30,15 +23,13 @@ jobs:
           submodules: true
 
       - uses: cachix/install-nix-action@v31
-
       - run: echo "Preparing Nix shell"
-
       - run: dune build --profile=release
       - run: dune runtest --force
 
   build_test_slower:
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: [ build_test ]
     if: "! ( cancelled() || success() )"
 

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -1,0 +1,68 @@
+name: build and test (using nix)
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  build_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: exec nix develop .#ci --ignore-env --keep-env-var CI --command {0}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: cachix/install-nix-action@v31
+
+      - run: echo "Preparing Nix shell"
+
+      - run: dune build --profile=release
+      - run: dune runtest --force
+
+  build_test_slower:
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    needs: [ build_test ]
+    if: "! ( cancelled() || success() )"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: ocaml/setup-ocaml@v3
+
+      - run: opam option --global 'archive-mirrors+="https://opam.ocaml.org/cache"'
+      - run: opam repository --all add pac https://github.com/uq-pac/opam-repository.git
+      - run: opam install . --deps-only --with-test
+      - run: echo LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib" >> "$GITHUB_ENV"
+        if: ${{ matrix.os }} == "macos-latest"
+      - run: opam lint
+      - run: opam exec -- dune build @fmt --display=quiet
+      - run: opam exec -- dune build --ignore-promoted-rules --profile=release
+      - run: opam exec -- dune build --ignore-promoted-rules '@treesit'
+      - run: opam exec -- dune runtest --ignore-promoted-rules --force
+
+  at_least_one_success:
+    runs-on: ubuntu-latest
+    needs: [ build_test, build_test_slower ]
+    if: >
+      needs.build_test.result == "success" || needs.build_test_slower.result == "success"
+

--- a/.github/workflows/test-using-nix.yml
+++ b/.github/workflows/test-using-nix.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: nix develop .#ci --ignore-env --keep-env-var CI --command {0}
+        shell: nix develop .#ci --ignore-env --keep-env-var CI --command bash {0}
 
     steps:
       - uses: actions/checkout@v5

--- a/bincaml.opam
+++ b/bincaml.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/username/reponame"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/username/reponame/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.20"}
   "ocaml"
   "unionFind"
   "capstone_arm64_disas"

--- a/bincaml_lsp.opam
+++ b/bincaml_lsp.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/username/reponame"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/username/reponame/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.20"}
   "menhir" {>= "20180523"}
   "ppx_expect"
   "bincaml"

--- a/capstone_arm64_disas.opam
+++ b/capstone_arm64_disas.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/username/reponame"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/username/reponame/issues"
 depends: [
-  "dune" {>= "3.24"}
+  "dune" {>= "3.20"}
   "ocaml"
   "ppx_expect"
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.24)
+(lang dune 3.20)
 
 (using menhir 3.0)
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   nixConfig.extra-substituters = [ "https://pac-nix.cachix.org/" ];
-  nixConfig.extra-trusted-public-keys = [ "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc=" ];
+  nixConfig.extra-trusted-public-keys = [
+    "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc="
+  ];
 
   inputs = {
     self.submodules = true;
@@ -40,7 +42,7 @@
     in
     flake-for-all-systems args {
       overlays = {
-        addBincamlPackages = ofinal: _: {
+        addBincamlPackages = ofinal: oprev: {
           buildDune324Package = ofinal.buildDunePackage.override {
             dune_3 = ofinal.dune_3_24;
           };
@@ -64,6 +66,20 @@
           kittyimg = ofinal.callPackage ./nix/kittyimg.nix { };
           stb_image = ofinal.callPackage ./nix/stb_image.nix { };
           containers = ofinal.callPackage ./nix/containers.nix { };
+
+          odoc =
+            (oprev.odoc.override {
+              cmdliner = ofinal.cmdliner;
+            }).overrideAttrs
+              (
+                f: p: {
+                  doCheck = false;
+                  propagatedBuildInputs = (p.propagatedBuildInputs or [ ]) ++ (p.buildInputs or [ ]) ++ [ofinal.ppx_expect];
+                }
+              );
+          sherlodoc = ofinal.callPackage ./nix/sherlodoc.nix { };
+          odoc-md = ofinal.callPackage ./nix/odoc-md.nix { };
+          odoc-driver = ofinal.callPackage ./nix/odoc-driver.nix { };
         };
 
         enableOcamlFramePointer =
@@ -92,10 +108,12 @@
         }:
         let
           pkgs = nixpkgs.legacyPackages;
-          ocamlPackages = pkgs.ocamlPackages.overrideScope (_: _: {
-            z3-bin = pkgs.z3;
-            inherit (pac-nix.legacyPackages) bnfc-treesitter;
-          });
+          ocamlPackages = pkgs.ocamlPackages.overrideScope (
+            _: _: {
+              z3-bin = pkgs.z3;
+              inherit (pac-nix.legacyPackages) bnfc-treesitter;
+            }
+          );
           selfOcamlPackages = ocamlPackages.overrideScope self.overlays.addBincamlPackages;
           fpOcamlPackages = selfOcamlPackages.overrideScope self.overlays.enableOcamlFramePointer;
         in
@@ -103,6 +121,8 @@
           defaultPackage = selfOcamlPackages.bincaml;
 
           legacyPackages = {
+            ocamlPackages = selfOcamlPackages;
+
             bincaml = selfOcamlPackages.bincaml;
             bincaml_lsp = selfOcamlPackages.bincaml_lsp;
             aslp_lifter_ocaml = selfOcamlPackages.aslp_lifter_ocaml;
@@ -128,13 +148,13 @@
           devShells = {
             default = self.devShells.fp;
             fp = fpOcamlPackages.callPackage ./nix/shell.nix {
-              includeEditorTools = true;
+              isShellForCI = false;
             };
             no-fp = selfOcamlPackages.callPackage ./nix/shell.nix {
-              includeEditorTools = true;
+              isShellForCI = false;
             };
             ci = selfOcamlPackages.callPackage ./nix/shell.nix {
-              includeEditorTools = false;
+              isShellForCI = true;
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
   ];
 
   inputs = {
-    self.submodules = true;
 
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
@@ -58,6 +57,7 @@
           capstone_arm64_disas = ofinal.callPackage ./nix/capstone_arm64_disas.nix {
             buildDunePackage = ofinal.buildDune324Package;
           };
+          bincaml-docs = ofinal.callPackage ./nix/bincaml-docs.nix { };
 
           ocaml-protoc-plugin-6-1-0 = ofinal.callPackage ./nix/ocaml-protoc-plugin.nix { };
           aslp_lifter_ocaml = ofinal.callPackage ./nix/aslp-lifter-ocaml.nix { };

--- a/flake.nix
+++ b/flake.nix
@@ -88,10 +88,12 @@
           ...
         }:
         let
-          inherit (pac-nix.legacyPackages) bnfc-treesitter;
-
           pkgs = nixpkgs.legacyPackages;
-          selfOcamlPackages = pkgs.ocamlPackages.overrideScope self.overlays.addBincamlPackages;
+          ocamlPackages = pkgs.ocamlPackages.overrideScope (_: _: {
+            z3-bin = pkgs.z3;
+            inherit (pac-nix.legacyPackages) bnfc-treesitter;
+          });
+          selfOcamlPackages = ocamlPackages.overrideScope self.overlays.addBincamlPackages;
           fpOcamlPackages = selfOcamlPackages.overrideScope self.overlays.enableOcamlFramePointer;
         in
         {
@@ -123,12 +125,10 @@
           devShells = {
             default = self.devShells.fp;
             fp = fpOcamlPackages.callPackage ./nix/shell.nix {
-              inherit bnfc-treesitter;
-              z3 = pkgs.z3.out;
+              includeEditorTools = true;
             };
             no-fp = selfOcamlPackages.callPackage ./nix/shell.nix {
-              inherit bnfc-treesitter;
-              z3 = pkgs.z3.out;
+              includeEditorTools = true;
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,7 @@
 {
+  nixConfig.extra-substituters = [ "https://pac-nix.cachix.org/" ];
+  nixConfig.extra-trusted-public-keys = [ "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc=" ];
+
   inputs = {
     self.submodules = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,9 @@
             no-fp = selfOcamlPackages.callPackage ./nix/shell.nix {
               includeEditorTools = true;
             };
+            ci = selfOcamlPackages.callPackage ./nix/shell.nix {
+              includeEditorTools = false;
+            };
           };
         };
     };

--- a/nix/aslp-lifter-ocaml.nix
+++ b/nix/aslp-lifter-ocaml.nix
@@ -24,7 +24,6 @@ buildDunePackage (self: {
 
   outputs = [
     "out"
-    "dev"
   ];
 
   meta = {

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -8,6 +8,7 @@ odoc-driver,
 odoc,
 findlib,
 ocaml,
+fmt,
 sherlodoc,
 runtimeShell
 }:
@@ -28,7 +29,7 @@ let
 
 env = buildEnv {
 name = "ajidso";
-  paths = [ odoc ];
+  paths = [ fmt ];
   includeClosures = true;
   pathsToLink = [ "/share/doc" "/lib/ocaml/5.4.1/site-lib" ];
 
@@ -50,5 +51,5 @@ in runCommand "bincaml-docs" {
   mkdir -p $(dirname $dune_prefix)
   ln -s ${env} $dune_prefix
   ls -l $(dirname $dune_prefix)
-  OCAMLPATH=$dune_prefix/lib odoc_driver --html-dir=$out $(cd $dune_prefix/lib && echo *)
+  OCAMLPATH=$dune_prefix/lib odoc_driver --html-dir=$out -v $(cd $dune_prefix/lib && echo *)
 ''

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -35,9 +35,10 @@ name = "ajidso";
   postBuild = ''
     mv $out/share/doc doc
     mv $out/lib/ocaml/*/site-lib lib
+    ln -s ${ocaml}/lib/ocaml lib
 
     rm -rf $out
-    mkdir $out
+    mkdir -v $out
     mv doc lib $out
   '';
 };

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -1,0 +1,53 @@
+{
+buildEnv,
+runCommand,
+writeShellScriptBin,
+odoc-driver,
+  bincaml,
+  bincaml_lsp,
+odoc,
+findlib,
+ocaml,
+sherlodoc,
+runtimeShell
+}:
+
+let
+  dummy-opam = runCommand "dummy-opam" {
+  } ''
+    mkdir -pv $out/lib $out/bin
+    cp ${findlib}/etc/findlib.conf $out/lib
+    cp -r ${ocaml}/lib/ocaml $out/lib/ocaml
+
+    cat <<EOF > $out/bin/opam
+    #!${runtimeShell}
+    echo $out
+    EOF
+    chmod +x $out/bin/opam
+  '';
+
+env = buildEnv {
+name = "ajidso";
+  paths = [ odoc ];
+  includeClosures = true;
+  pathsToLink = [ "/share/doc" "/lib/ocaml/5.4.1/site-lib" ];
+
+  postBuild = ''
+    mv $out/share/doc doc
+    mv $out/lib/ocaml/*/site-lib lib
+
+    rm -rf $out
+    mkdir $out
+    mv doc lib $out
+  '';
+};
+
+in runCommand "bincaml-docs" {
+  nativeBuildInputs = [ dummy-opam odoc-driver odoc sherlodoc ocaml ];
+} ''
+  dune_prefix=$(mktemp -d)/_build/install/default
+  mkdir -p $(dirname $dune_prefix)
+  ln -s ${env} $dune_prefix
+  ls -l $(dirname $dune_prefix)
+  OCAMLPATH=$dune_prefix/lib odoc_driver --html-dir=$out $(cd $dune_prefix/lib && echo *)
+''

--- a/nix/bincaml-lsp.nix
+++ b/nix/bincaml-lsp.nix
@@ -34,18 +34,14 @@ buildDunePackage {
     logs
     fmt
     iter
-    linol
-    linol-lwt
     containers
     ppx_deriving
+    linol
+    linol-lwt
   ];
-  propagatedBuildInputs = [ ];
 
   doCheck = true;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -40,6 +40,12 @@
   qcheck-core,
   qcheck-alcotest,
   qcheck-stm,
+  tree-sitter,
+  nodejs-slim,
+  bnfc-treesitter,
+  boogie,
+  cvc5,
+  z3-bin, # custom name for z3 binary, since `z3` is the ocaml library
 
   # dev:
   # , odig
@@ -65,6 +71,14 @@ buildDunePackage {
     qcheck-core
     qcheck-alcotest
     qcheck-stm
+  ];
+  nativeCheckInputs = [
+    tree-sitter
+    nodejs-slim
+    bnfc-treesitter
+    boogie
+    cvc5
+    z3-bin.out
   ];
   nativeBuildInputs = [
     writableTmpDirAsHomeHook
@@ -110,10 +124,7 @@ buildDunePackage {
   '';
 
   doCheck = true;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/capstone_arm64_disas.nix
+++ b/nix/capstone_arm64_disas.nix
@@ -43,10 +43,7 @@ buildDunePackage {
   propagatedBuildInputs = [ capstone ];
 
   doCheck = false;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/odoc-driver.nix
+++ b/nix/odoc-driver.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch2,
   buildDunePackage,
 
   odoc,
@@ -22,6 +23,13 @@
 buildDunePackage {
   pname = "odoc-driver";
   inherit (odoc) version src;
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/ocaml/odoc/commit/02408309dc223f8ab97a023dfec4e4641ec55736.patch";
+      hash = "sha256-FO2QaK1TaxCNBpttFy/GHnePa6uvKOvxE+rstKcPY/Q=";
+    })
+  ];
 
   nativeBuildInputs = [ sherlodoc ];
   buildInputs = [

--- a/nix/odoc-driver.nix
+++ b/nix/odoc-driver.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildDunePackage,
+
+  odoc,
+  odoc-md,
+  fpath,
+  bos,
+  yojson,
+  findlib,
+  opam-format,
+  logs,
+  eio_main,
+  eio,
+  progress,
+  cmdliner,
+  sexplib,
+  ppx_sexp_conv,
+  sherlodoc,
+}:
+
+buildDunePackage {
+  pname = "odoc-driver";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [ sherlodoc ];
+  buildInputs = [
+    odoc
+    odoc-md
+    fpath
+    bos
+    yojson
+    findlib
+    opam-format
+    logs
+    eio_main
+    eio
+    progress
+    cmdliner
+    sexplib
+    ppx_sexp_conv
+  ];
+
+  nativeCheckInputs = [ ];
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = {
+    description = "OCaml Documentation Generator - Driver";
+    mainProgram = "odoc_driver";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc";
+    changelog = "https://github.com/ocaml/odoc/blob/${odoc.version}/CHANGES.md";
+  };
+}

--- a/nix/odoc-md.nix
+++ b/nix/odoc-md.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildDunePackage,
+
+  odoc,
+  cmdliner,
+  cmarkit,
+}:
+
+buildDunePackage {
+  pname = "odoc-md";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [ ];
+  buildInputs = [
+    odoc
+    cmdliner
+    cmarkit
+  ];
+
+  nativeCheckInputs = [ ];
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = {
+    description = "OCaml Documentation Generator - Markdown support";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc";
+    changelog = "https://github.com/ocaml/odoc/blob/${odoc.version}/CHANGES.md";
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,6 +10,7 @@
   bincaml_lsp,
   capstone_arm64_disas,
   odoc,
+  odoc-driver,
   odig,
   ocaml-lsp,
   ocamlformat,
@@ -22,9 +23,9 @@
 mkShell {
   packages = [
     odoc
+    odoc-driver
     odig
     ocamlformat
-    # sherlodoc - not in nixpkgs?
   ]
 
   ++ lib.optionals (!isShellForCI) (
@@ -69,5 +70,8 @@ mkShell {
         ln -sf $i/* "$ODIG_LIB_DIR"
       done
     fi
+  '' + lib.optionalString isShellForCI ''
+    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
+    export OPAMCOLOR=never
   '';
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,6 @@
 {
+  includeEditorTools,
+
   lib,
   stdenv,
   mkShell,
@@ -6,55 +8,41 @@
   # ocaml packages
   bincaml,
   bincaml_lsp,
+  capstone_arm64_disas,
   odoc,
   odig,
   ocaml-lsp,
   ocamlformat,
 
   # dev packages
-  tree-sitter,
-  nodejs-slim,
   perf,
-  bnfc-treesitter,
-  boogie,
-  cvc5,
-  linol-lwt,
-  linol,
-  capstone,
-
-  # lsp
-  logs,
-  mtime,
-  z3,
 }:
 
 mkShell {
-  buildInputs = [
-    capstone
-  ];
-
   packages = [
     odoc
     odig
-    ocaml-lsp
     ocamlformat
-    tree-sitter
-    nodejs-slim
-    bnfc-treesitter
-    boogie
-    cvc5
-    bincaml_lsp
-    linol
-    linol-lwt
-    logs
-    mtime
-    z3.out
     # sherlodoc - not in nixpkgs?
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux perf;
+  ++ lib.optionals includeEditorTools (
+    [
+      bincaml_lsp
+      ocaml-lsp
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux perf
+  );
 
   inputsFrom = [
     (bincaml.overrideAttrs { doCheck = true; })
+    (capstone_arm64_disas.overrideAttrs { doCheck = true; })
+    (bincaml_lsp.overrideAttrs { doCheck = true; })
+
+    # including these unchanged will subtract them from the dependencies of each other:
+    # https://github.com/NixOS/nixpkgs/blob/f9bb1890175874edf242921789e8e9fdfcc2023c/pkgs/build-support/mkshell/default.nix#L32-L34
+    bincaml
+    capstone_arm64_disas
+    bincaml_lsp
   ];
 
   shellHook = ''

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,5 @@
 {
-  includeEditorTools,
+  isShellForCI,
 
   lib,
   stdenv,
@@ -13,6 +13,7 @@
   odig,
   ocaml-lsp,
   ocamlformat,
+  opam,
 
   # dev packages
   perf,
@@ -25,13 +26,18 @@ mkShell {
     ocamlformat
     # sherlodoc - not in nixpkgs?
   ]
-  ++ lib.optionals includeEditorTools (
+
+  ++ lib.optionals (!isShellForCI) (
     [
       bincaml_lsp
       ocaml-lsp
     ]
     ++ lib.optional stdenv.hostPlatform.isLinux perf
-  );
+  )
+
+  ++ lib.optionals (isShellForCI) [
+    opam
+  ];
 
   inputsFrom = [
     (bincaml.overrideAttrs { doCheck = true; })

--- a/nix/sherlodoc.nix
+++ b/nix/sherlodoc.nix
@@ -66,11 +66,18 @@ buildDunePackage (self: {
 
   preCheck = ''
     substituteInPlace sherlodoc/test/dune --replace-quiet --quiet ""
-    export ODIG_LIB_DIR="$(echo ${tyxml}/lib/ocaml/*/site-lib)"
-    export ODIG_DOC_DIR="${tyxml}/share/doc"
-    export LOG_LEVEL=stderr
+
+    cat <<EOF >> sherlodoc/test/dune
+    (env
+     (_
+      (env-vars
+       (ODIG_LIB_DIR $(echo ${tyxml}/lib/ocaml/*/site-lib))
+       (ODIG_DOC_DIR ${tyxml}/share/doc)
+       (LOG_LEVEL info)
+       )))
+    EOF
+
     opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
-    export OPAMCOLOR=never
   '';
 
   meta = {

--- a/nix/sherlodoc.nix
+++ b/nix/sherlodoc.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildDunePackage,
+  writableTmpDirAsHomeHook,
+
+  odoc,
+  base64,
+  bigstringaf,
+  js_of_ocaml,
+  brr,
+  cmdliner,
+  decompress,
+  fpath,
+  lwt,
+  menhir,
+  ppx_blob,
+  tyxml,
+  odig,
+  base,
+  alcotest,
+  findlib,
+}:
+
+buildDunePackage (self: {
+  pname = "sherlodoc";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [
+    menhir
+    js_of_ocaml
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    odoc
+    findlib
+    base64
+    bigstringaf
+    brr
+    cmdliner
+    decompress
+    fpath
+    lwt
+    ppx_blob
+    tyxml
+    base
+    alcotest
+  ];
+
+  nativeCheckInputs = [
+    odig
+    odoc
+  ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  postPatch = ''
+    substituteInPlace sherlodoc/test/dune --replace-quiet --quiet ""
+  '';
+
+  meta = {
+    description = "Search engine for OCaml documentation";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc";
+  };
+})

--- a/nix/sherlodoc.nix
+++ b/nix/sherlodoc.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  fetchpatch2,
   buildDunePackage,
   writableTmpDirAsHomeHook,
 
+  opam,
   odoc,
   base64,
   bigstringaf,
@@ -24,6 +26,13 @@
 buildDunePackage (self: {
   pname = "sherlodoc";
   inherit (odoc) version src;
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/ocaml/odoc/commit/9695cd79ec29c082f62c768a99a650ebf06892d3.patch";
+      hash = "sha256-8eyclSV4MnMkVcT+0NjPKWARzITm6tJpg0n/Z7Yi/L4=";
+    })
+  ];
 
   nativeBuildInputs = [
     menhir
@@ -50,12 +59,18 @@ buildDunePackage (self: {
   nativeCheckInputs = [
     odig
     odoc
+    opam
   ];
   checkInputs = [ alcotest ];
   doCheck = true;
 
-  postPatch = ''
+  preCheck = ''
     substituteInPlace sherlodoc/test/dune --replace-quiet --quiet ""
+    export ODIG_LIB_DIR="$(echo ${tyxml}/lib/ocaml/*/site-lib)"
+    export ODIG_DOC_DIR="${tyxml}/share/doc"
+    export LOG_LEVEL=stderr
+    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
+    export OPAMCOLOR=never
   '';
 
   meta = {

--- a/run-in-nix-shell.sh
+++ b/run-in-nix-shell.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+nix develop .#ci --ignore-env --keep-env-var CI --command "$@"

--- a/run-in-nix-shell.sh
+++ b/run-in-nix-shell.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -eu
 
-nix develop .#ci --ignore-env --keep-env-var CI --command "$@"
+exec nix develop .#ci --ignore-env --keep-env-var CI --command "$@"


### PR DESCRIPTION
i am back on the nix opam shell grind. i want it to give a fast path for ci which is less maintenance steps and less flaky than the docker image. it should still support falling back to opam install in case the nix shell is missing some packages, so that a failing nix build doesn't block CI.

i'm abandoning my approach from last week, because that approach was using opam install --fake which is "dangerous and likely to break your opam environment". the goal of that was to somehow "teach" opam about the nixpkgs ocaml packages so opam will only install the missing ones, but i think this would be very fragile and didn't get to a proof of concept stage.

instead, i think it can be something much simpler. you just use all nixpkgs ocaml packages and if that fails, then use all opam packages. it's a lot slower in the fallback case, but hopefully that should be rare enough that it doesn't matter.

future work (beyond today), will look at caching the nixpkgs packages in github actions

- [ ] port other jobs too 
- [ ] gate thingy behind all nix jobs succeeding