### PR TITLE
nix: add `.#bincamlDocs.docs` to run `odoc_driver` using nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig.extra-substituters = [ "https://pac-nix.cachix.org/" ];
+  nixConfig.extra-trusted-public-keys = [
+    "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc="
+  ];
+
   inputs = {
     self.submodules = true;
 
@@ -53,6 +58,7 @@
           capstone_arm64_disas = ofinal.callPackage ./nix/capstone_arm64_disas.nix {
             buildDunePackage = ofinal.buildDune324Package;
           };
+          bincamlDocs = ofinal.callPackage ./nix/bincaml-docs.nix { };
 
           ocaml-protoc-plugin-6-1-0 = ofinal.callPackage ./nix/ocaml-protoc-plugin.nix { };
           aslp_lifter_ocaml = ofinal.callPackage ./nix/aslp-lifter-ocaml.nix { };
@@ -61,6 +67,17 @@
           kittyimg = ofinal.callPackage ./nix/kittyimg.nix { };
           stb_image = ofinal.callPackage ./nix/stb_image.nix { };
           containers = ofinal.callPackage ./nix/containers.nix { };
+
+          odoc_3_2 = ofinal.callPackage ./nix/odoc.nix { };
+          sherlodoc = ofinal.callPackage ./nix/sherlodoc.nix {
+            odoc = ofinal.odoc_3_2;
+          };
+          odoc-md = ofinal.callPackage ./nix/odoc-md.nix {
+            odoc = ofinal.odoc_3_2;
+          };
+          odoc-driver = ofinal.callPackage ./nix/odoc-driver.nix {
+            odoc = ofinal.odoc_3_2;
+          };
         };
 
         enableOcamlFramePointer =
@@ -88,16 +105,23 @@
           ...
         }:
         let
-          inherit (pac-nix.legacyPackages) bnfc-treesitter;
-
           pkgs = nixpkgs.legacyPackages;
-          selfOcamlPackages = pkgs.ocamlPackages.overrideScope self.overlays.addBincamlPackages;
+          ocamlPackages = pkgs.ocamlPackages.overrideScope (
+            _: _: {
+              z3-bin = pkgs.z3;
+              inherit (pac-nix.legacyPackages) bnfc-treesitter;
+            }
+          );
+          selfOcamlPackages = ocamlPackages.overrideScope self.overlays.addBincamlPackages;
           fpOcamlPackages = selfOcamlPackages.overrideScope self.overlays.enableOcamlFramePointer;
         in
         {
           defaultPackage = selfOcamlPackages.bincaml;
 
           legacyPackages = {
+            ocamlPackages = selfOcamlPackages;
+            bincamlDocs = selfOcamlPackages.bincamlDocs;
+
             bincaml = selfOcamlPackages.bincaml;
             bincaml_lsp = selfOcamlPackages.bincaml_lsp;
             aslp_lifter_ocaml = selfOcamlPackages.aslp_lifter_ocaml;
@@ -123,12 +147,13 @@
           devShells = {
             default = self.devShells.fp;
             fp = fpOcamlPackages.callPackage ./nix/shell.nix {
-              inherit bnfc-treesitter;
-              z3 = pkgs.z3.out;
+              isShellForCI = false;
             };
             no-fp = selfOcamlPackages.callPackage ./nix/shell.nix {
-              inherit bnfc-treesitter;
-              z3 = pkgs.z3.out;
+              isShellForCI = false;
+            };
+            ci = selfOcamlPackages.callPackage ./nix/shell.nix {
+              isShellForCI = true;
             };
           };
         };

--- a/nix/aslp-lifter-ocaml.nix
+++ b/nix/aslp-lifter-ocaml.nix
@@ -24,7 +24,6 @@ buildDunePackage (self: {
 
   outputs = [
     "out"
-    "dev"
   ];
 
   meta = {

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -1,0 +1,151 @@
+/**
+  Facilitates generating ocamldocs for the Bincaml package and its dependencies.
+*/
+{
+  lib,
+  newScope,
+}:
+
+lib.makeScope newScope (
+  self:
+  let
+    callPackage = self.callPackage;
+  in
+  {
+    /**
+      Usually, `odoc_driver` uses opam to discover packages, but we don't have
+      a real opam switch in Nix. Fortunately, `odoc_driver` also has the ability
+      to load packages from Dune's `_build` folder structure, implemented in the
+      `dune_overrides` function:
+        https://github.com/ocaml/odoc/blob/v3.1/src/driver/opam.ml#L228
+
+      This derivation transforms the separate Nix packages for Bincaml and its
+      dependencies into this Dune-like folder structure expected by `odoc_driver`.
+    */
+    fake_dune_prefix = callPackage (
+      {
+        ocaml,
+        buildEnv,
+        fmt,
+        yojson_2,
+        bos,
+      }:
+      (buildEnv {
+        name = "fake-dune-prefix-for-odoc";
+        paths = [
+          fmt # TODO: change to bincaml and bincaml_lsp
+        ];
+        includeClosures = true;
+        ignoreCollisions = false;
+        pathsToLink = [
+          "/share/doc"
+          "/lib/ocaml/${ocaml.version}/site-lib"
+        ];
+        postBuild = ''
+          d=$out/_build/install/default
+
+          mkdir -p $d $out/bin
+          mv -v $out/share/doc $d/doc
+          mv -v $out/lib/ocaml/*/site-lib $d/lib
+
+          mkdir $d/lib/ocaml
+          ln -s ${ocaml}/lib/ocaml/* $d/lib/ocaml
+
+          # this makes the builtin packages (like `unix`) appear
+          # as distinct top-level packages rather than being under
+          # `ocaml`. we probably need to fake `.changes` to avoid this.
+          for meta in ${ocaml}/lib/ocaml/*/META; do
+            ln -s $(dirname $meta) $d/lib
+          done
+
+          rm -rf $out/share $out/lib
+          rm -rf $d/lib/{compiler-libs,stdlib,topfind,stublibs}
+
+          cat <<EOF > $out/bin/activate_fake_dune_prefix.sh
+          export OCAMLPATH=$d/lib
+          EOF
+          chmod +x $out/bin/*
+        '';
+      }).overrideAttrs
+        (
+          _: prev: {
+            # `linol` (and others?) depend on hardcoded `yojson_2` which leads
+            # to both yojson 3 and 2 in the closure, which causes conflicts.
+            buildCommand = ''
+              grep -v ${yojson_2} $extraPathsFrom > without_yojson
+              extraPathsFrom=without_yojson
+              ${prev.buildCommand}
+            '';
+          }
+        )
+    ) { };
+
+    /**
+      Provides a no-op `opam` script which prints a path to an empty dir.
+    */
+    fake_opam = callPackage (
+      {
+        writeShellScriptBin,
+        emptyDirectory,
+      }:
+      (writeShellScriptBin "opam" "echo ${emptyDirectory}").overrideAttrs { name = "fake-opam-for-odoc"; }
+    ) { };
+
+    /**
+      Main output which builds the HTML/JS/CSS for the documentation website.
+
+      Also has a `dev` output which contains the `.odocl` files for Sherlodoc.
+    */
+    docs = callPackage (
+      {
+        stdenvNoCC,
+        emptyDirectory,
+        fake_opam,
+        fake_dune_prefix,
+        ocaml,
+        findlib,
+        odoc,
+        sherlodoc,
+        odoc-driver,
+      }:
+      stdenvNoCC.mkDerivation {
+        name = "bincaml-docs";
+
+        dontUnpack = true;
+        doCheck = true;
+
+        nativeBuildInputs = [
+          ocaml
+          findlib
+          odoc
+          odoc-driver
+          sherlodoc
+          fake_opam
+          fake_dune_prefix
+        ];
+
+        outputs = [ "out" "dev" ];
+
+        buildPhase = ''
+          source activate_fake_dune_prefix.sh
+          odoc_driver \
+            --html-dir=$out \
+            --mld-dir=$dev --odoc-dir=$dev --odocl-dir=$dev \
+            $(cd $OCAMLPATH && echo *)
+
+          ocamlfind printconf
+
+          echo ${fake_opam}
+          echo ${fake_dune_prefix}
+        '';
+
+        checkPhase = ''
+          [[ -f $out/ocaml/stdlib/index.html ]] || {
+            echo "stdlib index.html missing. stdlib links are probably broken."
+            exit 1
+          }
+        '';
+      }
+    ) { };
+  }
+)

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -63,6 +63,7 @@ lib.makeScope newScope (
 
           cat <<EOF > $out/bin/activate_fake_dune_prefix.sh
           export OCAMLPATH=$d/lib
+          export CAMLLIB=$d/lib/ocaml
           EOF
           chmod +x $out/bin/*
         '';

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -1,0 +1,148 @@
+/**
+  Facilitates generating ocamldocs for the Bincaml package and its dependencies.
+*/
+{ lib, newScope }:
+
+lib.makeScope newScope (
+  self:
+  let
+    callPackage = self.callPackage;
+  in
+  {
+    /**
+      Usually, `odoc_driver` uses opam to discover packages, but we don't have
+      a real opam switch in Nix. Fortunately, `odoc_driver` also has the ability
+      to load packages from Dune's `_build` folder structure, implemented in the
+      `dune_overrides` function:
+        https://github.com/ocaml/odoc/blob/v3.1/src/driver/opam.ml#L228
+
+      This derivation transforms the separate Nix packages for Bincaml and its
+      dependencies into this Dune-like folder structure expected by `odoc_driver`.
+    */
+    fake_dune_prefix = callPackage (
+      {
+        ocaml,
+        buildEnv,
+        fmt,
+        yojson_2,
+        bos,
+      }:
+      (buildEnv {
+        name = "fake-dune-prefix-for-odoc";
+        # TODO: change to bincaml and bincaml_lsp
+        paths = [ fmt ];
+        includeClosures = true;
+        ignoreCollisions = false;
+        pathsToLink = [
+          "/share/doc"
+          "/lib/ocaml/${ocaml.version}/site-lib"
+        ];
+        postBuild = ''
+          d=$out/_build/install/default
+
+          mkdir -p $d $out/bin
+          mv -v $out/share/doc $d/doc
+          mv -v $out/lib/ocaml/*/site-lib $d/lib
+
+          mkdir $d/lib/ocaml
+          ln -s ${ocaml}/lib/ocaml/* $d/lib/ocaml
+
+          # the builtin packages (like `unix`) have no top-level META
+          # file and only have META files in subdirectories of ocaml/.
+          # this moves them up one level so that odoc can find them.
+          for meta in ${ocaml}/lib/ocaml/*/META; do
+            ln -s $(dirname $meta) $d/lib
+          done
+
+          rm -rf $out/share $out/lib
+          rm -rf $d/lib/{compiler-libs,stdlib,topfind,stublibs}
+
+          cat <<EOF > $out/bin/activate_fake_dune_prefix.sh
+          export OCAMLPATH=$d/lib
+          export CAMLLIB=$d/lib/ocaml
+          EOF
+          chmod +x $out/bin/*
+        '';
+      }).overrideAttrs
+        (
+          _: prev: {
+            # `linol` (and others?) depend on hardcoded `yojson_2` which leads
+            # to both yojson 3 and 2 in the closure, which causes conflicts.
+            buildCommand = ''
+              grep -v ${yojson_2} $extraPathsFrom > without_yojson
+              extraPathsFrom=without_yojson
+              ${prev.buildCommand}
+            '';
+          }
+        )
+    ) { };
+
+    /**
+      Provides a no-op `opam` script which prints a path to an empty dir.
+    */
+    fake_opam = callPackage (
+      { writeShellScriptBin, emptyDirectory }:
+      (writeShellScriptBin "opam" "echo ${emptyDirectory}").overrideAttrs { name = "fake-opam-for-odoc"; }
+    ) { };
+
+    /**
+      Main output which builds the HTML/JS/CSS for the documentation website.
+
+      Also has a `dev` output which contains the `.odocl` files for Sherlodoc.
+    */
+    docs = callPackage (
+      {
+        stdenvNoCC,
+        emptyDirectory,
+        fake_opam,
+        fake_dune_prefix,
+        ocaml,
+        findlib,
+        odoc,
+        sherlodoc,
+        odoc-driver,
+      }:
+      stdenvNoCC.mkDerivation {
+        name = "bincaml-docs";
+
+        dontUnpack = true;
+        doCheck = true;
+
+        nativeBuildInputs = [
+          ocaml
+          findlib
+          odoc
+          odoc-driver
+          sherlodoc
+          fake_opam
+          fake_dune_prefix
+        ];
+
+        outputs = [
+          "out"
+          "dev"
+        ];
+
+        buildPhase = ''
+          source activate_fake_dune_prefix.sh
+          odoc_driver \
+            --html-dir=$out \
+            --mld-dir=$dev --odoc-dir=$dev --odocl-dir=$dev \
+            $(cd $OCAMLPATH && echo *)
+
+          ocamlfind printconf
+
+          echo ${fake_opam}
+          echo ${fake_dune_prefix}
+        '';
+
+        checkPhase = ''
+          [[ -f $out/ocaml/stdlib/index.html ]] || {
+            echo "stdlib index.html missing. stdlib links are probably broken."
+            exit 1
+          }
+        '';
+      }
+    ) { };
+  }
+)

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -23,14 +23,13 @@ lib.makeScope newScope (
       {
         ocaml,
         buildEnv,
-        fmt,
+        bincaml_lsp,
         yojson_2,
         bos,
       }:
       (buildEnv {
         name = "fake-dune-prefix-for-odoc";
-        # TODO: change to bincaml and bincaml_lsp
-        paths = [ fmt ];
+        paths = [ bincaml_lsp ];
         includeClosures = true;
         ignoreCollisions = false;
         pathsToLink = [
@@ -98,7 +97,7 @@ lib.makeScope newScope (
         fake_dune_prefix,
         ocaml,
         findlib,
-        odoc,
+        odoc_3_2, # FIXME: use a wrapper instead of `odoc` on path
         sherlodoc,
         odoc-driver,
       }:
@@ -111,7 +110,7 @@ lib.makeScope newScope (
         nativeBuildInputs = [
           ocaml
           findlib
-          odoc
+          odoc_3_2
           odoc-driver
           sherlodoc
           fake_opam

--- a/nix/bincaml-lsp.nix
+++ b/nix/bincaml-lsp.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildDunePackage,
-  nix-gitignore,
   writableTmpDirAsHomeHook,
 
   # ocaml packages
@@ -25,7 +24,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "5.0";
 
-  src = nix-gitignore.gitignoreSource [ "nix" "flake.nix" "flake.lock" ] ./..;
+  inherit (bincaml) src;
 
   checkInputs = [ ];
   nativeBuildInputs = [ writableTmpDirAsHomeHook ];
@@ -34,18 +33,14 @@ buildDunePackage {
     logs
     fmt
     iter
-    linol
-    linol-lwt
     containers
     ppx_deriving
+    linol
+    linol-lwt
   ];
-  propagatedBuildInputs = [ ];
 
   doCheck = true;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -40,6 +40,12 @@
   qcheck-core,
   qcheck-alcotest,
   qcheck-stm,
+  tree-sitter,
+  nodejs-slim,
+  bnfc-treesitter,
+  boogie,
+  cvc5,
+  z3-bin, # custom name for z3 binary, since `z3` is the ocaml library
 
   # dev:
   # , odig
@@ -65,6 +71,14 @@ buildDunePackage {
     qcheck-core
     qcheck-alcotest
     qcheck-stm
+  ];
+  nativeCheckInputs = [
+    tree-sitter
+    nodejs-slim
+    bnfc-treesitter
+    boogie
+    cvc5
+    z3-bin.out
   ];
   nativeBuildInputs = [
     writableTmpDirAsHomeHook
@@ -110,10 +124,7 @@ buildDunePackage {
   '';
 
   doCheck = true;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/capstone_arm64_disas.nix
+++ b/nix/capstone_arm64_disas.nix
@@ -1,12 +1,12 @@
 {
   lib,
   buildDunePackage,
-  nix-gitignore,
   writableTmpDirAsHomeHook,
   capstone,
 
   # ocaml packages
-  ocaml
+  ocaml,
+  bincaml,
 
   # test:
 
@@ -19,18 +19,14 @@ buildDunePackage {
 
   minimalOCamlVersion = "5.0";
 
-  src = nix-gitignore.gitignoreSource [ "nix" "flake.nix" "flake.lock" ] ./..;
+  inherit (bincaml) src;
 
   checkInputs = [ ];
   nativeBuildInputs = [ writableTmpDirAsHomeHook ];
   buildInputs = [ ocaml ];
   propagatedBuildInputs = [ capstone ];
 
-  doCheck = false;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/capstone_arm64_disas.nix
+++ b/nix/capstone_arm64_disas.nix
@@ -1,11 +1,11 @@
 {
   lib,
   buildDunePackage,
-  nix-gitignore,
   writableTmpDirAsHomeHook,
   capstone,
 
   # ocaml packages
+  bincaml,
   logs,
   fmt,
   iter,
@@ -26,7 +26,7 @@ buildDunePackage {
 
   minimalOCamlVersion = "5.0";
 
-  src = nix-gitignore.gitignoreSource [ "nix" "flake.nix" "flake.lock" ] ./..;
+  inherit (bincaml) src;
 
   checkInputs = [ ];
   nativeBuildInputs = [ writableTmpDirAsHomeHook ];
@@ -42,11 +42,7 @@ buildDunePackage {
   ];
   propagatedBuildInputs = [ capstone ];
 
-  doCheck = false;
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   meta = {
     homepage = "https://github.com/agle/bincaml";

--- a/nix/odoc-driver.nix
+++ b/nix/odoc-driver.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildDunePackage,
+
+  odoc,
+  odoc-md,
+  fpath,
+  bos,
+  yojson,
+  findlib,
+  opam-format,
+  logs,
+  eio_main,
+  eio,
+  progress,
+  cmdliner,
+  sexplib,
+  ppx_sexp_conv,
+  sherlodoc,
+}:
+
+buildDunePackage {
+  pname = "odoc-driver";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [ sherlodoc ];
+  buildInputs = [
+    odoc
+    odoc-md
+    fpath
+    bos
+    yojson
+    findlib
+    opam-format
+    logs
+    eio_main
+    eio
+    progress
+    cmdliner
+    sexplib
+    ppx_sexp_conv
+  ];
+
+  postPatch = ''
+    substituteInPlace src/driver/ocamlfind.ml \
+      --replace-fail '~config ~env_camllib' "" \
+      --replace-fail 'let config =' 'let _config =' \
+      --replace-fail 'let env_camllib =' 'let _env_camllib ='
+
+    substituteInPlace src/driver/ocamlfind.ml --replace-fail 'let libname_of_archive =' 'let libname_of_archive =
+    (fun x ->
+      Fpath.Map.dump Format.pp_print_text Format.err_formatter x;
+      x) @@'
+  '';
+
+  nativeCheckInputs = [ ];
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = {
+    description = "OCaml Documentation Generator - Driver";
+    mainProgram = "odoc_driver";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc";
+    changelog = "https://github.com/ocaml/odoc/blob/${odoc.version}/CHANGES.md";
+  };
+}

--- a/nix/odoc-driver.nix
+++ b/nix/odoc-driver.nix
@@ -46,11 +46,6 @@ buildDunePackage {
       --replace-fail '~config ~env_camllib' "" \
       --replace-fail 'let config =' 'let _config =' \
       --replace-fail 'let env_camllib =' 'let _env_camllib ='
-
-    substituteInPlace src/driver/ocamlfind.ml --replace-fail 'let libname_of_archive =' 'let libname_of_archive =
-    (fun x ->
-      Fpath.Map.dump Format.pp_print_text Format.err_formatter x;
-      x) @@'
   '';
 
   nativeCheckInputs = [ ];

--- a/nix/odoc-md.nix
+++ b/nix/odoc-md.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildDunePackage,
+
+  odoc,
+  cmdliner,
+  cmarkit,
+}:
+
+buildDunePackage {
+  pname = "odoc-md";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [ ];
+  buildInputs = [
+    odoc
+    cmdliner
+    cmarkit
+  ];
+
+  nativeCheckInputs = [ ];
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = {
+    description = "OCaml Documentation Generator - Markdown support";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc";
+    changelog = "https://github.com/ocaml/odoc/blob/${odoc.version}/CHANGES.md";
+  };
+}

--- a/nix/odoc.nix
+++ b/nix/odoc.nix
@@ -1,0 +1,26 @@
+/**
+  Patches `ocamlPackages.odoc` to fix its dependency specification and enable use
+  as a library. Also update the version to fix failing cmdliner tests.
+*/
+{
+  odoc,
+  fetchurl,
+  cmdliner,
+  ppx_expect,
+}:
+
+(odoc.override {
+  cmdliner = cmdliner;
+}).overrideAttrs
+  (
+    _: prev: {
+      version = "3.2.1";
+      src = fetchurl {
+        url = "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz";
+        hash = "sha256-1F6xJVFIOf2awncCu0k40bTztpeOmxarlnPqBnJFr/w=";
+      };
+
+      propagatedBuildInputs =
+        (prev.propagatedBuildInputs or [ ]) ++ (prev.buildInputs or [ ]) ++ [ ppx_expect ];
+    }
+  )

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,6 @@
 {
+  isShellForCI,
+
   lib,
   stdenv,
   mkShell,
@@ -6,55 +8,48 @@
   # ocaml packages
   bincaml,
   bincaml_lsp,
+  capstone_arm64_disas,
   odoc,
+  odoc-driver,
   odig,
   ocaml-lsp,
   ocamlformat,
+  opam,
 
   # dev packages
-  tree-sitter,
-  nodejs-slim,
   perf,
-  bnfc-treesitter,
-  boogie,
-  cvc5,
-  linol-lwt,
-  linol,
-  capstone,
-
-  # lsp
-  logs,
-  mtime,
-  z3,
 }:
 
 mkShell {
-  buildInputs = [
-    capstone
-  ];
-
   packages = [
     odoc
+    odoc-driver
     odig
-    ocaml-lsp
     ocamlformat
-    tree-sitter
-    nodejs-slim
-    bnfc-treesitter
-    boogie
-    cvc5
-    bincaml_lsp
-    linol
-    linol-lwt
-    logs
-    mtime
-    z3.out
-    # sherlodoc - not in nixpkgs?
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux perf;
+
+  ++ lib.optionals (!isShellForCI) (
+    [
+      bincaml_lsp
+      ocaml-lsp
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux perf
+  )
+
+  ++ lib.optionals (isShellForCI) [
+    opam
+  ];
 
   inputsFrom = [
     (bincaml.overrideAttrs { doCheck = true; })
+    (capstone_arm64_disas.overrideAttrs { doCheck = true; })
+    (bincaml_lsp.overrideAttrs { doCheck = true; })
+
+    # including these unchanged will subtract them from the dependencies of each other:
+    # https://github.com/NixOS/nixpkgs/blob/f9bb1890175874edf242921789e8e9fdfcc2023c/pkgs/build-support/mkshell/default.nix#L32-L34
+    bincaml
+    capstone_arm64_disas
+    bincaml_lsp
   ];
 
   shellHook = ''
@@ -75,5 +70,8 @@ mkShell {
         ln -sf $i/* "$ODIG_LIB_DIR"
       done
     fi
+  '' + lib.optionalString isShellForCI ''
+    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
+    export OPAMCOLOR=never
   '';
 }

--- a/nix/sherlodoc.nix
+++ b/nix/sherlodoc.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildDunePackage,
+  writableTmpDirAsHomeHook,
+
+  opam,
+  odoc,
+  base64,
+  bigstringaf,
+  js_of_ocaml,
+  brr,
+  cmdliner,
+  decompress,
+  fpath,
+  lwt,
+  menhir,
+  ppx_blob,
+  tyxml,
+  odig,
+  base,
+  alcotest,
+  findlib,
+}:
+
+buildDunePackage (self: {
+  pname = "sherlodoc";
+  inherit (odoc) version src;
+
+  nativeBuildInputs = [
+    menhir
+    js_of_ocaml
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    odoc
+    findlib
+    base64
+    bigstringaf
+    brr
+    cmdliner
+    decompress
+    fpath
+    lwt
+    ppx_blob
+    tyxml
+    base
+    alcotest
+  ];
+
+  nativeCheckInputs = [
+    odig
+    odoc
+    opam
+  ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  preCheck = ''
+    substituteInPlace sherlodoc/test/dune --replace-quiet --quiet ""
+
+    cat <<EOF >> sherlodoc/test/dune
+    (env
+     (_
+      (env-vars
+       (ODIG_LIB_DIR $(echo ${tyxml}/lib/ocaml/*/site-lib))
+       (ODIG_DOC_DIR ${tyxml}/share/doc)
+       (OPAMCOLOR never)
+       (LOG_LEVEL info)
+       )))
+    EOF
+
+    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
+  '';
+
+  meta = {
+    description = "Search engine for OCaml documentation";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.katrinafyi ];
+    homepage = "https://github.com/ocaml/odoc/tree/master/sherlodoc";
+  };
+})


### PR DESCRIPTION
this turns the documentation site into a Nix package, so we can (eventually) simplify the CI/CD for doc generation.

you can test it with:

    nix build .#bincamlDocs.docs -Lv

at the moment, it just builds the docs for the `fmt` package to keep it fast and small, but when it's done, it will build all the bincaml docs - same as the current github workflow.

this involved packaging some odoc packages which were missing from nixpkgs. it also involves some careful folder structure construction and some faking, because the `odoc_driver` is built around the assumption of having opam switches.

at the moment, it all works *aside from* it miscategorises the builtin packages (like `unix`) as separate opam packages.

future work: sherlodoc

this PR also adjusts the `./.` sources to all reference the bincaml source, and changes the shell.nix so that more dependencies are properly specified in the package definitions so fewer packages need to be explicitly mentioned in the shell.