### PR TITLE
Store program declaration order explicitly

### DIFF
--- a/lib/analysis/wp_dual.ml
+++ b/lib/analysis/wp_dual.ml
@@ -211,10 +211,4 @@ proc @main () -> ()
   in
   IntraAnalysis.A.M.find Procedure.Vert.Entry res
   |> IntraDomain.to_pred |> BasilExpr.to_string |> print_endline;
-  [%expect
-    {|
-    Warn: global undeclared $x assuming mutable unshared
-    Warn: global undeclared $x assuming mutable unshared
-    Warn: global undeclared $x assuming mutable unshared
-    true
-    |}]
+  [%expect {| true |}]

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -475,9 +475,9 @@ let pretty_declaration (d : Program.declaration) =
   let open Containers_pp in
   let open Containers_pp.Infix in
   match d with
-  | Program.Variable { binding; attrib } ->
+  | Variable { binding; attrib } ->
       pretty_variable_declaration binding ^ text ";"
-  | Program.Function { binding; attrib; definition = Function t } ->
+  | Function { binding; attrib; definition = Function t } ->
       let func_body, return_type = pretty_function_body binding t in
 
       (* Ideally use above return type
@@ -492,12 +492,12 @@ let pretty_declaration (d : Program.declaration) =
       ^+ text "returns"
       ^+ bracket "(" return_type ")"
       ^+ surround ~width:2 (text "{") (newline ^ func_body) (newline ^ text "}")
-  | Program.Function { binding; attrib; definition = Axiom t } ->
+  | Function { binding; attrib; definition = Axiom t } ->
       fill sp [ text "axiom"; bracket "(" (pretty_expr t) ")" ] ^ text ";"
-  | Program.Function { binding; attrib; definition = Uninterpreted }
+  | Function { binding; attrib; definition = Uninterpreted }
     when List.is_empty (fst @@ Types.uncurry (Var.typ binding)) ->
       pretty_variable_declaration ~const:true binding ^ text ";"
-  | Program.Function { binding; attrib; definition = Uninterpreted } ->
+  | Function { binding; attrib; definition = Uninterpreted } ->
       let param, rt = Types.uncurry (Var.typ binding) in
       text "function"
       ^+ pretty_attribute_map ".boogie" attrib
@@ -509,8 +509,9 @@ let pretty_declaration (d : Program.declaration) =
           ")"
       ^ bracket " returns (" (text (type_to_string rt)) ")"
       ^ text ";"
-  | Program.Type { binding; typ } -> pretty_type_declaration binding typ
+  | Type { binding; typ } -> pretty_type_declaration binding typ
   | Procedure { definition } -> pretty_procedure definition
+  | Implicit _ -> failwith "cannot generate implicit"
 
 let pretty_program (p : Program.t) =
   let open Containers_pp in
@@ -519,7 +520,8 @@ let pretty_program (p : Program.t) =
     |> List.partition_filter_map (fun d ->
         let p = pretty_declaration d in
         match d with
-        | Program.Variable _ | Program.Function _ | Program.Type _ -> `Left p
+        | Variable _ | Function _ | Type _ -> `Left p
+        | Implicit _ -> `Drop
         | _ -> `Right p)
   in
   let glob_vars = append_nl glob_vars_funs in

--- a/lib/lang/expr_smt.ml
+++ b/lib/lang/expr_smt.ml
@@ -507,6 +507,7 @@ module SMTLib2 = struct
         @@ list
              [ atom "declare-fun"; smt_symbol (Var.name binding); list args; r ]
     | Variable v -> failwith "mutable"
+    | Implicit v -> failwith "implicit decl"
     | Procedure p -> failwith "procedure"
 
   let assert_bexpr e =

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -143,6 +143,23 @@ let infer_decl st visit_constraint prog scheme =
           Type { binding; typ = to_basil (TypeExpr.find st ty) }
         in
         (scheme, `Decl (decl_id, nty))
+    | Implicit (VariantCase { constructor; variant; belongs_to }) ->
+        let scheme = decl_var_typ st global_universe scheme constructor in
+        let binding s = retype_var st global_universe s constructor in
+        let ret_type () =
+          (* I'd hope this doesn't change... should equal return type of binding *)
+          ty_of_basil st belongs_to |> TypeExpr.find st |> to_basil
+        in
+        let new_def fscheme =
+          Implicit
+            (VariantCase
+               {
+                 constructor = binding fscheme;
+                 belongs_to = ret_type ();
+                 variant;
+               })
+        in
+        (scheme, `Decl (decl_id, new_def))
     | Function { binding; definition; attrib } -> (
         (* elaboration of var binding *)
         let scheme = decl_var_typ st global_universe scheme binding in

--- a/lib/lang/program.ml
+++ b/lib/lang/program.ml
@@ -27,10 +27,6 @@ let decl_is_typ = function Type _ -> true | _ -> false
 let decl_is_func = function Function _ -> true | _ -> false
 let decl_is_var = function Variable _ -> true | _ -> false
 let decl_is_proc = function Procedure _ -> true | _ -> false
-let types_before _ k = not (decl_is_typ k)
-let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k
-let procs_before _ k = decl_is_proc k
-let funcs_before _ k = decl_is_func k
 
 let decl_binding = function
   | Type { binding } -> binding
@@ -183,6 +179,9 @@ let get_id_by_name name prog = prog.global_names.get_id name
 let add_decl
     ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
       `Append) p decl =
+  let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k in
+  let procs_before _ k = decl_is_proc k in
+  let funcs_before _ k = decl_is_func k in
   let d = p.global_names.decl_or_get (decl_binding decl) in
   let declarations =
     match at with

--- a/lib/lang/program.ml
+++ b/lib/lang/program.ml
@@ -2,11 +2,7 @@ open Common
 open Types
 open Expr
 open Containers
-
-type e = BasilExpr.t
-type proc = (Var.t, BasilExpr.t) Procedure.t
-type bloc = (Var.t, BasilExpr.t) Block.t
-type stmt = (Var.t, Var.t, e) Stmt.t
+include Program_types
 
 module Proc = struct
   type t = proc
@@ -25,35 +21,23 @@ let show_stmt =
 
 let pp_stmt fmt s = Format.pp_print_string fmt (show_stmt s)
 
-type prog_spec = { rely : BasilExpr.t list; guarantee : BasilExpr.t list }
-type func_type = Axiom of e | Uninterpreted | Function of e
+module DeclsList = Bincaml_util.Indexed_list.Make (ID)
 
-type implicit_declaration =
-  | VariantCase of {
-      variant : string;
-      belongs_to : Types.t;
-      constructor : Var.t; (* function to construct a value of this case *)
-    }
-
-type declaration =
-  | Type of { binding : string; typ : Types.t }
-  | Function of {
-      binding : Var.t;
-      attrib : Attrib.attrib_map;
-      definition : func_type;
-    }  (** pure functions *)
-  | Variable of {
-      binding : Var.t;
-      attrib : Attrib.attrib_map;
-      classification : e option;
-    }
-  | Procedure of { definition : proc }
+let decl_is_typ = function Type _ -> true | _ -> false
+let decl_is_func = function Function _ -> true | _ -> false
+let decl_is_var = function Variable _ -> true | _ -> false
+let decl_is_proc = function Procedure _ -> true | _ -> false
+let types_before _ k = not (decl_is_typ k)
+let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k
+let procs_before _ k = decl_is_proc k
+let funcs_before _ k = decl_is_func k
 
 let decl_binding = function
   | Type { binding } -> binding
   | Variable { binding } -> Var.name binding
   | Function { binding } -> Var.name binding
   | Procedure { definition } -> ID.to_string (Procedure.id definition)
+  | Implicit (VariantCase _) -> failwith "variant case has no binding :("
 
 let pretty_proc p =
   let show_lvar v = Containers_pp.text @@ Var.to_string_il_lvar v in
@@ -64,6 +48,7 @@ let pretty_proc p =
 let pretty_declaration d =
   let open Containers_pp in
   match d with
+  | Implicit _ -> failwith "unsupp"
   | Variable { binding; attrib; classification } ->
       let classification =
         classification |> Option.to_list
@@ -102,8 +87,7 @@ let pretty_declaration d =
 
 type t = {
   modulename : string;
-  declarations : declaration IDMap.t;
-  implicit_decls : implicit_declaration IDMap.t;
+  declarations : declaration DeclsList.t;
   entry_proc : ID.t option;
   global_names : ID.generator;
   attrib : Attrib.attrib_map;
@@ -121,7 +105,7 @@ let entry_proc_exn p =
   p.entry_proc |> function
   | None -> raise Not_found
   | Some i -> (
-      IDMap.get i p.declarations |> function
+      DeclsList.get i p.declarations |> function
       | Some (Procedure { definition }) -> definition
       | _ -> raise Not_found)
 
@@ -132,32 +116,32 @@ let map_procedures f p =
     p with
     declarations =
       p.declarations
-      |> IDMap.mapi (fun i -> function
+      |> DeclsList.mapi (fun _ i -> function
         | Procedure { definition } -> Procedure { definition = f i definition }
         | o -> o);
   }
 
 let proc prog p =
-  IDMap.find p prog.declarations |> function
+  DeclsList.find p prog.declarations |> function
   | Procedure { definition } -> definition
   | _ -> raise Not_found
 
 let proc_opt prog p = try Some (proc prog p) with Not_found -> None
 
 let procs p =
-  IDMap.to_iter p.declarations
+  DeclsList.to_iter p.declarations
   |> Iter.filter_map (function
     | k, Procedure { definition } -> Some (k, definition)
     | _ -> None)
 
 let global_vars prog =
-  IDMap.values prog.declarations
+  DeclsList.values prog.declarations
   |> Iter.filter_map (function
     | Variable { binding } -> Some binding
     | _ -> None)
 
 let global_constants prog =
-  IDMap.values prog.declarations
+  DeclsList.values prog.declarations
   |> Iter.filter_map (function
     | Function { binding } -> Some binding
     | _ -> None)
@@ -165,10 +149,10 @@ let global_constants prog =
 let get_decl_by_name_id name prog =
   try
     let id = prog.global_names.get_id name in
-    IDMap.find_opt id prog.declarations |> Option.map (fun v -> (id, v))
+    DeclsList.find_opt id prog.declarations |> Option.map (fun v -> (id, v))
   with Not_found -> None
 
-let get_decl id prog = IDMap.find_opt id prog.declarations
+let get_decl id prog = DeclsList.find_opt id prog.declarations
 let get_decl_by_name name prog = get_decl_by_name_id name prog |> Option.map snd
 
 let get_proc id prog =
@@ -184,20 +168,38 @@ let get_proc_by_name name prog =
 let get_implicit_decl_by_name name prog =
   try
     let id = prog.global_names.get_id name in
-    IDMap.find_opt id prog.implicit_decls
+    DeclsList.find_opt id prog.declarations |> function
+    | Some (Implicit i) -> Some i
+    | _ -> None
   with Not_found -> None
 
 let declare_name_exn name prog = prog.global_names.decl_exn name
 let declare_name name prog = prog.global_names.decl_or_get name
 let get_id_by_name name prog = prog.global_names.get_id name
 
-let add_decl ?(attrib = StringMap.empty) p decl =
+(** [add_decl ?at ~attrib prog decl] adds [decl] to the declaration list of
+    [prog]. [?at] defaults to [`Append] which is constant time. Note that all
+    other values of [at] take at least linear time. *)
+let add_decl
+    ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
+      `Append) ?(attrib = StringMap.empty) p decl =
   let d = p.global_names.decl_or_get (decl_binding decl) in
-  { p with declarations = IDMap.add d decl p.declarations }
+  let declarations =
+    match at with
+    | `Append -> DeclsList.append d decl p.declarations
+    | `Prepend -> DeclsList.prepend d decl p.declarations
+    | `BeforeFuncs ->
+        DeclsList.insert_before ~before:funcs_before d decl p.declarations
+    | `BeforeVars ->
+        DeclsList.insert_before ~before:vars_before d decl p.declarations
+    | `BeforeProcs ->
+        DeclsList.insert_before ~before:procs_before d decl p.declarations
+  in
+  { p with declarations }
 
 let remove_decl p decl =
   let d = p.global_names.decl_or_get (decl_binding decl) in
-  { p with declarations = IDMap.remove d p.declarations }
+  { p with declarations = DeclsList.remove d p.declarations }
 
 let update_decl ?(attrib = StringMap.empty) prog decl =
   add_decl ~attrib prog decl
@@ -206,46 +208,40 @@ let add_proc p prog =
   let id = Procedure.id p in
   {
     prog with
-    declarations = IDMap.add id (Procedure { definition = p }) prog.declarations;
+    declarations =
+      DeclsList.append id (Procedure { definition = p }) prog.declarations;
   }
 
 let update_proc id f (prog : t) =
   proc_opt prog id |> f |> function
   | Some proc ->
       (if not @@ ID.equal (Procedure.id proc) id then
-         { prog with declarations = IDMap.remove id prog.declarations }
+         { prog with declarations = DeclsList.remove id prog.declarations }
        else prog)
       |> add_proc proc
-  | None -> { prog with declarations = IDMap.remove id prog.declarations }
+  | None -> { prog with declarations = DeclsList.remove id prog.declarations }
 
 let output_proc_pretty chan p =
   output_string chan @@ Containers_pp.Pretty.to_string ~width:80 (pretty_proc p)
 
 let prog_pretty (p : t) =
   let open Containers_pp in
-  let open Containers_pp.Infix in
-  let globs =
-    IDMap.bindings p.declarations
-    |> List.sort (fun (_, decl) (_, decl2) ->
-        (* NOTE: Recursive types might require more logic here *)
-        match (decl, decl2) with
-        | Type _, Type _ | Variable _, Variable _ | Function _, Function _ -> 0
-        | Type _, _ -> -1
-        | _, Type _ -> 1
-        | _ -> 0)
-    |> List.map (fun (n, v) -> pretty_declaration v)
+  let decls =
+    p.declarations |> DeclsList.to_iter
+    |> Iter.filter (function _, Implicit _ -> false | _ -> true)
+    |> Iter.map (fun (n, v) -> pretty_declaration v)
+    |> Iter.to_list
   in
   let n =
     p.entry_proc
     |> Option.map (fun i -> text "prog entry " ^ text @@ ID.to_string i)
     |> Option.to_list
   in
-  (* hopefullly ID map is sorted by id generator *)
-  let decls = globs @ n in
+  let decls = decls @ n in
 
   append_l ~sep:(text ";\n") decls ^ text ";\n"
 
-let declarations p = p.declarations |> IDMap.to_iter
+let declarations p = p.declarations |> DeclsList.to_iter
 
 let filter_decls f p =
   declarations p
@@ -254,7 +250,7 @@ let filter_decls f p =
          match f i d with
          | true -> prog
          | false ->
-             { prog with declarations = IDMap.remove i prog.declarations })
+             { prog with declarations = DeclsList.remove i prog.declarations })
        p
 
 let filter_map_decls f p =
@@ -263,7 +259,8 @@ let filter_map_decls f p =
        (fun prog (i, d) ->
          match f i d with
          | Some d -> update_decl prog d
-         | None -> { prog with declarations = IDMap.remove i prog.declarations })
+         | None ->
+             { prog with declarations = DeclsList.remove i prog.declarations })
        p
 
 let map_decls f p = filter_map_decls (fun id p -> Some (f id p)) p
@@ -281,7 +278,7 @@ let flat_map_decls f p =
          let next = f i decl in
          let prog = Iter.fold update_decl prog next in
          if !ex then prog
-         else { prog with declarations = IDMap.remove i prog.declarations })
+         else { prog with declarations = DeclsList.remove i prog.declarations })
        p
 
 (** Iterates over global variables in the given program, including both read and
@@ -304,7 +301,7 @@ let pretty_to_chan chan (p : t) =
 let decl_global ?(attrib = StringMap.empty) ?(classification = None) p v =
   let id : ID.t = p.global_names.decl_exn (Var.name v) in
   let decl = Variable { binding = v; attrib; classification } in
-  { p with declarations = IDMap.add id decl p.declarations }
+  { p with declarations = DeclsList.append id decl p.declarations }
 
 let decl_typ ?(attrib = StringMap.empty) p t =
   match t with
@@ -313,29 +310,30 @@ let decl_typ ?(attrib = StringMap.empty) p t =
       {
         p with
         declarations =
-          IDMap.add id (Type { binding = type_name; typ = s }) p.declarations;
+          DeclsList.add id
+            (Type { binding = type_name; typ = s })
+            p.declarations;
       }
   | Sort (name, variants) as s ->
       let id : ID.t = p.global_names.decl_exn name in
-      {
-        p with
-        declarations =
-          IDMap.add id (Type { binding = name; typ = s }) p.declarations;
-        implicit_decls =
-          IDMap.add_list p.implicit_decls
-            (variants
-            |> List.map (function { variant; fields } ->
-                let variant = p.global_names.decl_exn variant in
-                let args = List.map (function { field; typ } -> typ) fields in
-                let ty = Types.curry args s in
-                let constructor =
-                  Var.create (ID.name variant) ty ~scope:GlobalConst
-                in
-                ( variant,
-                  VariantCase
-                    { variant = ID.name variant; belongs_to = s; constructor }
-                )));
-      }
+
+      let new_decls =
+        (id, Type { binding = name; typ = s })
+        :: (variants
+           |> List.map (function { variant; fields } ->
+               let variant = p.global_names.decl_exn variant in
+               let args = List.map (function { field; typ } -> typ) fields in
+               let ty = Types.curry args s in
+               let constructor =
+                 Var.create (ID.name variant) ty ~scope:GlobalConst
+               in
+               ( variant,
+                 Implicit
+                   (VariantCase
+                      { variant = ID.name variant; belongs_to = s; constructor })
+               )))
+      in
+      { p with declarations = DeclsList.append_list new_decls p.declarations }
   | _ -> failwith "not declarable type"
 
 let create_single_proc ?(name = "<module>") () =
@@ -346,8 +344,8 @@ let create_single_proc ?(name = "<module>") () =
     {
       modulename = name;
       entry_proc = Some procname;
-      declarations = IDMap.singleton procname (Procedure { definition = proc });
-      implicit_decls = IDMap.empty;
+      declarations =
+        DeclsList.singleton procname (Procedure { definition = proc });
       global_names;
       attrib = StringMap.empty;
       spec = { rely = []; guarantee = [] };
@@ -360,8 +358,7 @@ let empty ?name () =
   {
     modulename;
     entry_proc = None;
-    declarations = IDMap.empty;
-    implicit_decls = IDMap.empty;
+    declarations = DeclsList.empty;
     global_names = ID.make_gen ();
     attrib = StringMap.empty;
     spec = { rely = []; guarantee = [] };

--- a/lib/lang/program.ml
+++ b/lib/lang/program.ml
@@ -182,7 +182,7 @@ let get_id_by_name name prog = prog.global_names.get_id name
     other values of [at] take at least linear time. *)
 let add_decl
     ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
-      `Append) ?(attrib = StringMap.empty) p decl =
+      `Append) p decl =
   let d = p.global_names.decl_or_get (decl_binding decl) in
   let declarations =
     match at with
@@ -201,8 +201,7 @@ let remove_decl p decl =
   let d = p.global_names.decl_or_get (decl_binding decl) in
   { p with declarations = DeclsList.remove d p.declarations }
 
-let update_decl ?(attrib = StringMap.empty) prog decl =
-  add_decl ~attrib prog decl
+let update_decl prog decl = add_decl prog decl
 
 let add_proc p prog =
   let id = Procedure.id p in

--- a/lib/lang/program.mli
+++ b/lib/lang/program.mli
@@ -56,13 +56,12 @@ val declare_name_exn : string -> t -> ID.t
 
 val add_decl :
   ?at:[ `Append | `BeforeFuncs | `BeforeProcs | `BeforeVars | `Prepend ] ->
-  ?attrib:'a StringMap.t ->
   t ->
   declaration ->
   t
 
 val remove_decl : t -> declaration -> t
-val update_decl : ?attrib:'a Types.StringMap.t -> t -> declaration -> t
+val update_decl : t -> declaration -> t
 val add_proc : (Var.t, Expr.BasilExpr.t) Procedure.t -> t -> t
 
 val update_proc :

--- a/lib/lang/program.mli
+++ b/lib/lang/program.mli
@@ -1,9 +1,10 @@
 open Common
+open Types
+open Expr
+open Containers
+include module type of Program_types
 
-type e = Expr.BasilExpr.t
-type proc = (Var.t, e) Procedure.t
-type bloc = (Var.t, e) Block.t
-type stmt = (Var.t, Var.t, e) Stmt.t
+type t
 
 module Proc : sig
   type t = proc
@@ -26,36 +27,9 @@ val show_stmt : (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t -> string
 val pp_stmt :
   Containers.Format.formatter -> (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t -> unit
 
-type prog_spec = { rely : e list; guarantee : e list }
-type func_type = Axiom of e | Uninterpreted | Function of e
-
-type implicit_declaration =
-  | VariantCase of {
-      variant : string;
-      belongs_to : Types.t;
-      constructor : Var.t;
-    }
-
-type declaration =
-  | Type of { binding : string; typ : Types.t }
-  | Function of {
-      binding : Var.t;
-      attrib : Attrib.attrib_map;
-      definition : func_type;
-    }
-  | Variable of {
-      binding : Var.t;
-      attrib : Attrib.attrib_map;
-      classification : e option;
-    }
-  | Procedure of { definition : proc }
-
 val decl_binding : declaration -> string
 val pretty_proc : (Var.t, Expr.BasilExpr.t) Procedure.t -> Containers_pp.t
 val pretty_declaration : declaration -> Containers_pp.t
-
-type t
-
 val get_id_by_name : string -> t -> ID.t
 val set_entry_proc : ID.t -> t -> t
 val set_spec : prog_spec -> t -> t
@@ -79,7 +53,14 @@ val get_proc : ID.t -> t -> proc
 val get_implicit_decl_by_name : string -> t -> implicit_declaration option
 val declare_name : string -> t -> ID.t
 val declare_name_exn : string -> t -> ID.t
-val add_decl : ?attrib:'a Types.StringMap.t -> t -> declaration -> t
+
+val add_decl :
+  ?at:[ `Append | `BeforeFuncs | `BeforeProcs | `BeforeVars | `Prepend ] ->
+  ?attrib:'a StringMap.t ->
+  t ->
+  declaration ->
+  t
+
 val remove_decl : t -> declaration -> t
 val update_decl : ?attrib:'a Types.StringMap.t -> t -> declaration -> t
 val add_proc : (Var.t, Expr.BasilExpr.t) Procedure.t -> t -> t

--- a/lib/lang/program_types.ml
+++ b/lib/lang/program_types.ml
@@ -1,0 +1,35 @@
+open Common
+open Types
+open Expr
+open Containers
+
+type e = Expr.BasilExpr.t
+type proc = (Var.t, e) Procedure.t
+type bloc = (Var.t, e) Block.t
+type stmt = (Var.t, Var.t, e) Stmt.t
+type prog_spec = { rely : e list; guarantee : e list }
+type func_type = Axiom of e | Uninterpreted | Function of e
+
+type implicit_declaration =
+  | VariantCase of {
+      variant : string;
+      belongs_to : Types.t;
+      constructor : Var.t;
+    }
+
+type declaration =
+  | Type of { binding : string; typ : Types.t }
+  | Function of {
+      binding : Var.t;
+      attrib : Attrib.attrib_map;
+      definition : func_type;
+    }  (** pure functions *)
+  | Variable of {
+      binding : Var.t;
+      attrib : Attrib.attrib_map;
+      classification : e option;
+    }
+  | Procedure of { definition : proc }
+  | Implicit of implicit_declaration
+      (** A declaration which is not explicitly present in the ir program, but
+          created by another construct, e.g. type constructors. *)

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -156,10 +156,22 @@ module BasilASTLoader = struct
     let prog =
       match x with
       | Module1 declarations ->
-          List.fold_left trans_declaration prog declarations |> fun p ->
-          List.fold_left trans_definition p declarations
+          let decls = List.fold_left trans_declaration prog declarations in
+          let decls = List.fold_left trans_definition decls declarations in
+          decls
     in
-    map_prog (fun prog -> Spec_modifies.set_modsets ~add_only:true prog) prog
+    let decls =
+      map_prog (fun prog -> Spec_modifies.set_modsets ~add_only:true prog) prog
+    in
+    decls
+
+  and trans_program_just_decls ?(lst : load_st option) ?(name = "<module>")
+      (x : moduleT) : load_st =
+    let prog =
+      match lst with Some lst -> lst | None -> load_st_empty ~name ()
+    in
+    match x with
+    | Module1 declarations -> List.fold_left trans_declaration prog declarations
 
   and var_modifiers_shared (m : varModifiers list) =
     if not @@ List.exists (function Shared | Observable -> true) m then
@@ -946,8 +958,9 @@ module BasilASTLoader = struct
                 (unsafe_unsigil (`Global bident))
                 (trans_type type')
             in
-            print_endline @@ "Warn: global undeclared " ^ Var.name v
-            ^ " assuming mutable unshared";
+            Logs.warn (fun m ->
+                m "Warn: global undeclared %s assuming mutable unshared "
+                  (Var.name v));
             v
         in
         assign_var prog v
@@ -1135,16 +1148,13 @@ module BasilASTLoader = struct
     match Program.get_decl_by_name vn p_st.prog with
     | Some (Variable { binding }) -> binding
     | Some (Function { binding }) -> binding
-    | Some (Type _) ->
-        let msg = "found type declaration when looking for variable:" ^ vn in
+    | Some (Implicit (VariantCase { constructor })) -> constructor
+    | Some _ ->
+        let msg = "found non-var declaration when looking for variable:" ^ vn in
         raise (LoadError { token_char_offset_range; msg; input = None })
-    | None -> (
-        match Program.get_implicit_decl_by_name vn p_st.prog with
-        | Some (VariantCase { constructor }) -> constructor
-        | None ->
-            let msg = "global variable used before declaration : " ^ vn in
-            raise (LoadError { token_char_offset_range; msg; input = None }))
-    | Some (Procedure _) -> failwith ""
+    | None ->
+        let msg = "global variable used before declaration : " ^ vn in
+        raise (LoadError { token_char_offset_range; msg; input = None })
 
   and trans_bv_val v : Bitvec.t =
     match v with
@@ -1608,17 +1618,17 @@ let load_single_block_proc ?(proc = "<proc>") ?input lexbuf =
     |> StringMap.of_list
   in
   let proc = Procedure.map_formal_in_params (fun _ -> inparam) proc in
-  let prog = Program.add_proc proc prog in
   let prog =
     Iter.append (Block.read_vars_iter bl) (Block.assigned_vars_iter bl)
     |> Iter.filter Var.is_global
     |> Iter.fold
          (fun prog v ->
            Program.add_decl prog
-             (Program.Variable
+             (Variable
                 { binding = v; attrib = StringMap.empty; classification = None }))
          prog
   in
+  let prog = Program.add_proc proc prog in
   (prog, proc, bl)
 
 let load_single_block ?proc ~input lexbuf =

--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -158,7 +158,7 @@ let add_aarch64_global_declarations ?(include_unused = false) prog =
        (fun prog v ->
          let binding = Aslp_lexpr.to_var v in
          let attrib = Attrib.empty and classification = None in
-         Program.add_decl prog
+         Program.add_decl ~at:`Prepend prog
            (Program.Variable { binding; attrib; classification }))
        prog
 

--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -154,6 +154,7 @@ let add_aarch64_global_declarations ?(include_unused = false) prog =
   |> List.to_iter
   |> Iter.filter (Aslp_lexpr.to_var %> include_predicate)
   |> Iter.map (Fun.tap (Aslp_lexpr.check_decl_type prog))
+  |> Iter.rev
   |> Iter.fold
        (fun prog v ->
          let binding = Aslp_lexpr.to_var v in

--- a/lib/transforms/function_summaries.ml
+++ b/lib/transforms/function_summaries.ml
@@ -147,6 +147,7 @@ let add_decls solver prog =
   |> Iter.filter
        Program.(
          function
+         | Implicit _ -> false
          | Type { binding } -> true
          | Variable { binding } -> Var.is_constant binding
          | Function { binding } -> Var.is_constant binding

--- a/lib/transforms/gamma_vars.ml
+++ b/lib/transforms/gamma_vars.ml
@@ -35,7 +35,7 @@ let add_globals ?(check_names = false) (add : Var.t -> bool) (p : Program.t) =
   |> Iter.fold
        (fun p (s, decl) ->
          match decl with
-         | Program.Variable { binding; attrib } when add binding ->
+         | Program_types.Variable { binding; attrib } when add binding ->
              if check_names then check_var binding;
              Program.decl_global ~attrib p (gamma_of binding)
          | _ -> p)

--- a/lib/transforms/may_read_uninit.ml
+++ b/lib/transforms/may_read_uninit.ml
@@ -157,8 +157,6 @@ let%expect_test "fold_block" =
   in
   [%expect
     {|
-    Warn: global undeclared $stack assuming mutable unshared
-    Warn: global undeclared $mem assuming mutable unshared
     ($stack->RU, R31_in->RU, R0_in->RU, _->⊥)
     ($stack->RU, R31_in->RU, R0_in->RU, load45_1->W, _->⊥)
     ($stack->RU, R31_in->RU, R0_in->RU, load45_1->W, R1_4->W, _->⊥)

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -167,7 +167,7 @@ module MemoryEncoder (Encoding : MemoryEncoding) = struct
   let add_decl ?(attrib = Attrib.empty) (p : Program.t) (name : string)
       (bindings : Var.t list) (body : BasilExpr.t) =
     let name = "$" ^ name in
-    Lang.Program.add_decl ~attrib p
+    Lang.Program.add_decl p
       (Lang.Program.Function
          {
            binding =

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -1,7 +1,10 @@
+; (include_subdirs qualified)
+
 (library
  (public_name bincaml.util)
  (name bincaml_util)
  (modules
+  indexed_list
   worklist
   fixed_width_arith
   mtypes

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -1,10 +1,12 @@
+(** Sequential and associative datastructure with fast iteration, appending, and
+    O(logn) indexing. *)
+
 open Containers
 
 module Make (K : Mtypes.ORD_TYPE) = struct
   module M = Map.Make (K)
 
   (* Order stored reverse *)
-
   type 'a t = { order : K.t list; values : 'a M.t }
   (** invariant : \forall x . x \in order == x \in M.keys values *)
 
@@ -22,20 +24,20 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   let of_list m = List.to_iter m |> of_iter
 
-  (* Get in-order iterator of keys *)
+  (** Get in-order iterator of keys *)
   let keys { order } = List.to_iter order |> Iter.rev
 
-  (* Get in-order iterator of key-value pairs  *)
+  (** Get in-order iterator of key-value pairs *)
   let to_iter { order; values } =
     List.to_iter order |> Iter.rev |> Iter.map (fun k -> (k, M.find k values))
 
-  (* Get in-order list of pairs of keys and values *)
+  (** Get in-order list of pairs of keys and values *)
   let to_list m = m |> to_iter |> Iter.to_list
 
-  (* Values iterator in-order  *)
+  (** Values iterator in-order *)
   let values m = to_iter m |> Iter.map snd
 
-  (* Values iterator out-of-order *)
+  (** Values iterator out-of-order *)
   let values_nondet { values } = M.values values
 
   (** [append k v m] replaces k -> v in m, in-place if it is already defined.
@@ -47,7 +49,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   (** [add k v m] replaces k -> v in m, in-place if it is already defined.
       Otherwise it is appended. This operation is the fastest insertion
-      operation (O(1)). *)
+      operation (O(1)). Identical to {!append}*)
   let add k v m = append k v m
 
   let prepend k v { order; values } =
@@ -68,7 +70,8 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let insert_before_key ~before k v m =
     insert_before ~before:(fun k _ -> K.equal before k) k v m
 
-  (** Insert value at absolute index. Index is clamped to [0..len-1]. *)
+  (** Insert value at absolute index. Negative indices count inwards from the
+      end of the list, idices greater than the length append. *)
   let insert_at_index ~before_index k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else
@@ -95,9 +98,17 @@ module Make (K : Mtypes.ORD_TYPE) = struct
     let values = List.fold_left (fun acc (k, v) -> M.add k v acc) values news in
     { order; values }
 
+  (** Lookup key, throwing [Not_found] if it does not exists. *)
   let find k { values } = M.find k values
+
+  (** Lookup key, returning [Some] if it exists. O(log n) *)
   let find_opt k { values } = M.find_opt k values
+
+  (** Lookup key, returning [Some] if it exists. O(log n) *)
   let get k { values } = M.find_opt k values
+
+  (** Lookup key, throwing [Not_found] if it does not exist *)
+  let get_exn k { values } = M.find k values
 
   (** Out-of-order map *)
   let map f { order; values } = { order; values = M.map f values }

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -1,0 +1,138 @@
+open Containers
+
+module Make (K : Mtypes.ORD_TYPE) = struct
+  module M = Map.Make (K)
+
+  (* Order stored reverse *)
+
+  type 'a t = { order : K.t list; values : 'a M.t }
+  (** invariant : \forall x . x \in order == x \in M.keys values *)
+
+  let empty = { order = []; values = M.empty }
+  let singleton k v = { order = [ k ]; values = M.singleton k v }
+
+  let of_iter m =
+    let m = Iter.persistent m in
+    let values = M.of_iter m in
+    (* we store in reverse order  *)
+    let order = m |> Iter.map fst |> Iter.to_rev_list in
+    (* no duplicate keys  *)
+    assert (Int.equal (M.cardinal values) (List.length order));
+    { values; order }
+
+  let of_list m = List.to_iter m |> of_iter
+
+  (* Get in-order iterator of keys *)
+  let keys { order } = List.to_iter order |> Iter.rev
+
+  (* Get in-order iterator of key-value pairs  *)
+  let to_iter { order; values } =
+    List.to_iter order |> Iter.rev |> Iter.map (fun k -> (k, M.find k values))
+
+  (* Get in-order list of pairs of keys and values *)
+  let to_list m = m |> to_iter |> Iter.to_list
+
+  (* Values iterator in-order  *)
+  let values m = to_iter m |> Iter.map snd
+
+  (* Values iterator out-of-order *)
+  let values_nondet { values } = M.values values
+
+  (** [append k v m] replaces k -> v in m, in-place if it is already defined.
+      Otherwise it is appended. This operation is the fastest insertion
+      operation (O(1)). *)
+  let append k v { order; values } =
+    if M.mem k values then { order; values = M.add k v values }
+    else { order = k :: order; values = M.add k v values }
+
+  (** [add k v m] replaces k -> v in m, in-place if it is already defined.
+      Otherwise it is appended. This operation is the fastest insertion
+      operation (O(1)). *)
+  let add k v m = append k v m
+
+  let prepend k v { order; values } =
+    if M.mem k values then { order; values = M.add k v values }
+    else { order = order @ [ k ]; values = M.add k v values }
+
+  let insert_before ~before k v { order; values } =
+    if M.mem k values then { order; values = M.add k v values }
+    else
+      let order = List.rev order in
+      let idx =
+        List.find_index (fun k -> before k (M.find k values)) order
+        |> Option.get_or ~default:(-1)
+      in
+      let order = List.insert_at_idx idx k order |> List.rev in
+      { order; values = M.add k v values }
+
+  let insert_before_key ~before k v m =
+    insert_before ~before:(fun k _ -> K.equal before k) k v m
+
+  (** Insert value at absolute index. Index is clamped to [0..len-1]. *)
+  let insert_at_index ~before_index k v { order; values } =
+    if M.mem k values then { order; values = M.add k v values }
+    else
+      let idx = List.length order - before_index in
+      let order = List.insert_at_idx idx k order in
+      { order; values = M.add k v values }
+
+  (** Relatively efficient: cons *)
+  let append_list news m = List.fold_left (fun acc (k, v) -> add k v acc) m news
+
+  let insert_list_before ~before news m =
+    let { values; order } = m in
+    let order = List.rev order in
+    let idx =
+      List.find_index (fun k -> before k (M.find k values)) order
+      |> Option.get_or ~default:(-1)
+    in
+    let add_ord =
+      List.filter (fun (id, _) -> not @@ M.mem id values) news |> List.map fst
+    in
+    let pre, post = List.take_drop idx order in
+    let order = List.rev @@ pre @ add_ord @ post in
+    (* update all values  *)
+    let values = List.fold_left (fun acc (k, v) -> M.add k v acc) values news in
+    { order; values }
+
+  let find k { values } = M.find k values
+  let find_opt k { values } = M.find_opt k values
+  let get k { values } = M.find_opt k values
+
+  (** Out-of-order map *)
+  let map f { order; values } = { order; values = M.map f values }
+
+  (** In-order map with both positional index and key *)
+  let mapi f m =
+    to_iter m |> Iter.mapi (fun ind (k, v) -> (k, f ind k v)) |> of_iter
+
+  let remove k { order; values } =
+    let values' = M.remove k values in
+    let order =
+      if not @@ Equal.physical values' values then
+        List.remove_one ~eq:K.equal k order
+      else order
+    in
+    { order; values = values' }
+
+  let update k f { order; values } =
+    match f (M.find_opt k values) with
+    | Some new_val -> { order; values = M.add k new_val values }
+    | None ->
+        let order = List.remove_one ~eq:K.equal k order in
+        let values = M.remove k values in
+        { order; values }
+
+  (** Sort keys: just List.sort *)
+  let sort_by_keys compar { order; values } =
+    let order = List.sort (Ord.opp compar) order in
+    { order; values }
+
+  (** less efficient sort on values; copies index *)
+  let sort (compar : (K.t * 'a) Ord.t) ({ order; values } : 'a t) =
+    let ord a b =
+      Ord.opp (Ord.map (fun k -> (k, M.find k values)) compar) a b
+    in
+    let order = List.sort ord order in
+    { order; values }
+end

--- a/test/analysis/test_ide_live.ml
+++ b/test/analysis/test_ide_live.ml
@@ -44,9 +44,6 @@ proc @main (a:bv64, b:bv64, c:bv64, d:bv64, e:bv64) -> ()
   print_lives results main;
   [%expect
     {|
-    Warn: global undeclared $x assuming mutable unshared
-    Warn: global undeclared $y assuming mutable unshared
-    Warn: global undeclared $z assuming mutable unshared
     @main
     $mem:(bv64->bv8)
     a:bv64

--- a/test/cram/expr_smt.t
+++ b/test/cram/expr_smt.t
@@ -6,7 +6,7 @@ Should output no errors
   (load-il ../../examples/cntlm-output.il)
   (run-transforms cf-expressions-smtcheck)
   (load-il concat.il)
-  Warn: global undeclared $__BranchTaken assuming mutable unshared
+  bincaml: [WARNING] Warn: global undeclared $__BranchTaken assuming mutable unshared 
   (dump-il before.il)
   (run-transforms cf-expressions-smtcheck)
   (dump-il after.il)

--- a/test/cram/gtirb.t
+++ b/test/cram/gtirb.t
@@ -24,6 +24,23 @@
   $ diff gtirb-output.il dumped.il
 
   $ cat semantics.il
+  var $PSTATE_V:bv1;
+  var $PSTATE_Z:bv1;
+  var $PSTATE_N:bv1;
+  var $R30:bv64;
+  var $R29:bv64;
+  var $R19:bv64;
+  var $R17:bv64;
+  var $R16:bv64;
+  var $R6:bv64;
+  var $R5:bv64;
+  var $R4:bv64;
+  var $R3:bv64;
+  var $R2:bv64;
+  var $R1:bv64;
+  var $R0:bv64;
+  var $SP:bv64;
+  var observable $mem:(bv64->bv8);
   var $PC:bv64;
   proc @_fini()  -> () {  }
     modifies $PC:bv64, $R29:bv64, $R30:bv64, $SP:bv64, $mem:(bv64->bv8)
@@ -1569,22 +1586,5 @@
      ];
      block %FUN_400620_code_1 [ assert boolor(); unreachable; ]
   ];
-  var observable $mem:(bv64->bv8);
-  var $SP:bv64;
-  var $R0:bv64;
-  var $R1:bv64;
-  var $R2:bv64;
-  var $R3:bv64;
-  var $R4:bv64;
-  var $R5:bv64;
-  var $R6:bv64;
-  var $R16:bv64;
-  var $R17:bv64;
-  var $R19:bv64;
-  var $R29:bv64;
-  var $R30:bv64;
-  var $PSTATE_N:bv1;
-  var $PSTATE_Z:bv1;
-  var $PSTATE_V:bv1;
   prog entry @_start;
 

--- a/test/cram/gtirb.t
+++ b/test/cram/gtirb.t
@@ -24,23 +24,23 @@
   $ diff gtirb-output.il dumped.il
 
   $ cat semantics.il
-  var $PSTATE_V:bv1;
-  var $PSTATE_Z:bv1;
-  var $PSTATE_N:bv1;
-  var $R30:bv64;
-  var $R29:bv64;
-  var $R19:bv64;
-  var $R17:bv64;
-  var $R16:bv64;
-  var $R6:bv64;
-  var $R5:bv64;
-  var $R4:bv64;
-  var $R3:bv64;
-  var $R2:bv64;
-  var $R1:bv64;
-  var $R0:bv64;
-  var $SP:bv64;
   var observable $mem:(bv64->bv8);
+  var $SP:bv64;
+  var $R0:bv64;
+  var $R1:bv64;
+  var $R2:bv64;
+  var $R3:bv64;
+  var $R4:bv64;
+  var $R5:bv64;
+  var $R6:bv64;
+  var $R16:bv64;
+  var $R17:bv64;
+  var $R19:bv64;
+  var $R29:bv64;
+  var $R30:bv64;
+  var $PSTATE_N:bv1;
+  var $PSTATE_Z:bv1;
+  var $PSTATE_V:bv1;
   var $PC:bv64;
   proc @_fini()  -> () {  }
     modifies $PC:bv64, $R29:bv64, $R30:bv64, $SP:bv64, $mem:(bv64->bv8)

--- a/test/cram/memassign.t
+++ b/test/cram/memassign.t
@@ -8,9 +8,8 @@
 
 
   $ cat memout.il |  grep Global -B 1 -A 1
-  type ilist = Cons of {head: bv64; tail: ilist} | Nil;
   var observable $Global_4325420_4325424:bv32 classification true;
-  let $mul_2 (a:bv64), (b:bv64) : bv64 = (bvadd(b:bv64, bvmul(a:bv64, 0x2:bv64)));
+  type uninterpSort = UninterpSort;
   --
       .returnBlock = "main_return" }
     modifies $Global_4325420_4325424:bv32

--- a/test/cram/roundtrip.t
+++ b/test/cram/roundtrip.t
@@ -27,12 +27,12 @@ Memassign repr
 
   $ diff beforemem.il aftermem.il
   $ cat aftermem.il
+  var observable $Global_4325420_4325424:bv32 classification true;
   type uninterpSort = UninterpSort;
   type opaque = A | B | C;
   type variants = AA of {a: bv64} | BB of {b: bv32} | CC of {c: bv8};
   type record = Record of {a: bv64; b: bv32; c: bv64};
   type ilist = Cons of {head: bv64; tail: ilist} | Nil;
-  var observable $Global_4325420_4325424:bv32 classification true;
   let $mul_2 (a:bv64), (b:bv64) : bv64 = (bvadd(b:bv64, bvmul(a:bv64, 0x2:bv64)));
   let $test (a:bv64) : bv64 = (if eq(a:bv64, 0x1:bv64) then 0xa:bv64 else 0xb:bv64);
   proc @main_4196164(R0_in:bv64, R10_in:bv64, R11_in:bv64, R12_in:bv64, R13_in:bv64,

--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,7 @@
 (library
  (name bincaml_inline_tests)
  (inline_tests)
- (modules test_expr_print)
- (libraries)
+ (modules test_expr_print test_util_indexlist)
+ (libraries bincaml.util)
  (preprocess
   (pps ppx_expect)))

--- a/test/lang/test_interp.ml
+++ b/test/lang/test_interp.ml
@@ -22,7 +22,6 @@ let%expect_test "fold_block" =
   ();
   [%expect
     {|
-    Warn: global undeclared $mem assuming mutable unshared
     PC= test::Return
     Stack
 

--- a/test/lang/test_stmt.ml
+++ b/test/lang/test_stmt.ml
@@ -54,8 +54,6 @@ let%expect_test "fold_block" =
   ();
   [%expect
     {|
-    Warn: global undeclared $stack assuming mutable unshared
-    Warn: global undeclared $mem assuming mutable unshared
     $stack:(bv64->bv8) := store le $stack:(bv64->bv8) bvadd(R31_in:bv64,
      0xfffffffffffffffc:bv64) extract(32,0, R0_in:bv64) 32
     var load45_1:bv32 := load le $stack:(bv64->bv8) bvadd(R31_in:bv64,

--- a/test/test_util_indexlist.ml
+++ b/test/test_util_indexlist.ml
@@ -1,0 +1,116 @@
+(* TODO decide on how flags should be tested (if at all) maybe only test in
+        expect tests and also symbolic bases probably*)
+
+module M = Bincaml_util.Indexed_list.Make (struct
+  include Int
+
+  let show = Int.to_string
+end)
+
+let ppair (a, b) = "(" ^ Int.to_string a ^ "," ^ Int.to_string b ^ ")"
+let pr msg m = print_endline @@ msg ^ ": " ^ Iter.to_string ppair (M.to_iter m)
+
+let%expect_test "app" =
+  let m = M.of_list [ (1, 1); (2, 2) ] in
+  pr "of list [1,1; 2,2]    " m;
+  let m = M.of_iter (CCList.to_iter [ (1, 1); (2, 2) ]) in
+  pr "of iter [1,1; 2,2]    " m;
+  let m = M.append 10 10 m in
+  pr "10,10 appended        " m;
+  let m = M.prepend 5 5 m in
+  pr "5,5 prepended         " m;
+  let m = M.prepend 1 2 m in
+  pr "1,1 replaced w. 1,2   " m;
+  let m = M.append 1 3 m in
+  pr "1,2 replaced w. 1,3   " m;
+  let m = M.insert_before ~before:(fun k v -> k = 2) 50 50 m in
+  pr "50,50 ins before (2,_)" m;
+  let m = M.insert_before_key ~before:50 11 11 m in
+  pr "11,11 ins before (50,)" m;
+  let m = M.insert_at_index ~before_index:1 12 12 m in
+  pr "12,12 ins at index 1  " m;
+  let m =
+    M.insert_list_before ~before:(fun k v -> k = 11) [ (21, 21); (22, 22) ] m
+  in
+  pr "[21,21;22,22]ins bf11," m;
+  let m = M.append_list [ (31, 31); (32, 32) ] m in
+  pr "[31,31;32,32] appended" m;
+  let m = M.map (fun v -> v + 1) m in
+  pr "map adding 1          " m;
+  let m = M.mapi (fun idx k v -> v + 1) m in
+  pr "mapi adding 1         " m;
+  let m = M.remove 21 m in
+  pr "remove 21             " m;
+  let m = M.remove 5 m in
+  pr "remove 5              " m;
+  let ms = M.sort (fun (_, a) (_, b) -> Int.compare a b) m in
+  pr "sort values           " ms;
+  let ms = M.sort_by_keys Int.compare m in
+  pr "sort keys             " ms;
+  ();
+  [%expect
+    {|
+    of list [1,1; 2,2]    : (1,1), (2,2)
+    of iter [1,1; 2,2]    : (1,1), (2,2)
+    10,10 appended        : (1,1), (2,2), (10,10)
+    5,5 prepended         : (5,5), (1,1), (2,2), (10,10)
+    1,1 replaced w. 1,2   : (5,5), (1,2), (2,2), (10,10)
+    1,2 replaced w. 1,3   : (5,5), (1,3), (2,2), (10,10)
+    50,50 ins before (2,_): (5,5), (1,3), (50,50), (2,2), (10,10)
+    11,11 ins before (50,): (5,5), (1,3), (11,11), (50,50), (2,2), (10,10)
+    12,12 ins at index 1  : (5,5), (12,12), (1,3), (11,11), (50,50), (2,2), (10,10)
+    [21,21;22,22]ins bf11,: (5,5), (12,12), (1,3), (21,21), (22,22), (11,11), (50,50), (2,2), (10,10)
+    [31,31;32,32] appended: (5,5), (12,12), (1,3), (21,21), (22,22), (11,11), (50,50), (2,2), (10,10), (31,31), (32,32)
+    map adding 1          : (5,6), (12,13), (1,4), (21,22), (22,23), (11,12), (50,51), (2,3), (10,11), (31,32), (32,33)
+    mapi adding 1         : (5,7), (12,14), (1,5), (21,23), (22,24), (11,13), (50,52), (2,4), (10,12), (31,33), (32,34)
+    remove 21             : (5,7), (12,14), (1,5), (22,24), (11,13), (50,52), (2,4), (10,12), (31,33), (32,34)
+    remove 5              : (12,14), (1,5), (22,24), (11,13), (50,52), (2,4), (10,12), (31,33), (32,34)
+    sort values           : (2,4), (1,5), (10,12), (11,13), (12,14), (22,24), (31,33), (32,34), (50,52)
+    sort keys             : (1,5), (2,4), (10,12), (11,13), (12,14), (22,24), (31,33), (32,34), (50,52)
+    |}]
+
+let%expect_test "append" =
+  let m = M.of_list [] in
+  let m = M.append_list [ (31, 31); (32, 32) ] m in
+  pr "[31,31;32,32] appended" m;
+  ();
+  [%expect {| [31,31;32,32] appended: (31,31), (32,32) |}]
+
+let%expect_test "remove empty" =
+  let m = M.remove 5 M.empty in
+  pr "remove from empty" m;
+  let m = M.append_list [ (31, 31); (32, 32) ] M.empty in
+  let m = M.remove 5 m in
+  pr "remove nonexistent" m;
+  let m = M.update 31 (function _ -> None) m in
+  pr "update rm  31     " m;
+  let m = M.update 32 (function Some k -> Some 33 | _ -> None) m in
+  pr "update 32->33     " m;
+  [%expect
+    {|
+    remove from empty:
+    remove nonexistent: (31,31), (32,32)
+    update rm  31     : (32,32)
+    update 32->33     : (32,33)
+    |}]
+
+let%expect_test "empty" =
+  let m = M.remove 5 M.empty in
+  pr "remove from empty" m;
+  let m = M.append_list [ (31, 31); (32, 32) ] M.empty in
+  let m = M.remove 5 m in
+  pr "remove nonexistent" m;
+  [%expect
+    {|
+    remove from empty:
+    remove nonexistent: (31,31), (32,32)
+    |}]
+
+open Containers
+
+let%expect_test "invalid from list" =
+  let () = Printexc.record_backtrace false in
+  let m = M.of_list [ (1, 31); (1, 32) ] in
+  pr "remove nonexistent" m;
+  [%expect.unreachable]
+[@@expect.uncaught_exn {| "Assert_failure lib/util/indexed_list.ml:20:4" |}]

--- a/test/test_util_indexlist.ml
+++ b/test/test_util_indexlist.ml
@@ -109,8 +109,9 @@ let%expect_test "empty" =
 open Containers
 
 let%expect_test "invalid from list" =
-  let () = Printexc.record_backtrace false in
-  let m = M.of_list [ (1, 31); (1, 32) ] in
-  pr "remove nonexistent" m;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| "Assert_failure lib/util/indexed_list.ml:20:4" |}]
+  try
+    let m = M.of_list [ (1, 31); (1, 32) ] in
+    pr "remove nonexistent" m
+  with Assert_failure _ ->
+    print_endline "assert failure";
+    [%expect {| assert failure |}]

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -151,11 +151,11 @@ proc @main()  -> () {  }
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
   [%expect
     {|
-    var $R30:bv64;
-    var $R29:bv64;
-    var $R1:bv64;
-    var $R0:bv64;
     var $SP:bv64;
+    var $R0:bv64;
+    var $R1:bv64;
+    var $R29:bv64;
+    var $R30:bv64;
     var observable $mem:(bv64->bv8);
     var $PC:bv64;
     proc @main()  -> () {  }
@@ -256,8 +256,8 @@ proc @Sqrt()  -> () {  }
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
   [%expect
     {|
-    var $PSTATE_V:bv1;
     var $PSTATE_N:bv1;
+    var $PSTATE_V:bv1;
     var observable $mem:(bv64->bv8);
     var $PC:bv64;
     proc @Sqrt()  -> () {  }

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -151,6 +151,11 @@ proc @main()  -> () {  }
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
   [%expect
     {|
+    var $R30:bv64;
+    var $R29:bv64;
+    var $R1:bv64;
+    var $R0:bv64;
+    var $SP:bv64;
     var observable $mem:(bv64->bv8);
     var $PC:bv64;
     proc @main()  -> () {  }
@@ -210,11 +215,6 @@ proc @main()  -> () {  }
        block %main_code_1 [ assert boolor(eq(0x400784:bv64, $PC)); goto (%ret_1); ];
        block %ret_1 [ return; ]
     ];
-    var $SP:bv64;
-    var $R0:bv64;
-    var $R1:bv64;
-    var $R29:bv64;
-    var $R30:bv64;
     prog entry @main;
     |}]
 
@@ -256,6 +256,8 @@ proc @Sqrt()  -> () {  }
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
   [%expect
     {|
+    var $PSTATE_V:bv1;
+    var $PSTATE_N:bv1;
     var observable $mem:(bv64->bv8);
     var $PC:bv64;
     proc @Sqrt()  -> () {  }
@@ -291,8 +293,6 @@ proc @Sqrt()  -> () {  }
        block %Sqrt_code_3 [ assume eq(0x4007fc:bv64, $PC); goto (%ret); ];
        block %ret [ return; ]
     ];
-    var $PSTATE_N:bv1;
-    var $PSTATE_V:bv1;
     prog entry @Sqrt;
     |}]
 


### PR DESCRIPTION
Fixes #235 

Declaration order is now defined by the order of operations over `program` via Program.add_decl (an immutable structure), rather than the order in which ID.fresh is called (which is side-effecting).

 `Program.add_decl` now takes the optional parameter `?at`, which allows inserting at a specific position in the declaration order.

```ocaml
(** [add_decl ?at ~attrib prog decl] adds [decl] to the declaration list of
[prog]. [?at] defaults to [`Append] which is constant time. Note that all other
values of [at] take at least linear time. *)
let add_decl
    ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
      `Append) ?(attrib = StringMap.empty) p decl =
```

Implementation

- util/indexed_list.ml: defines a map structure with a list defining its iteration order `'a t = {order: KEY.t List.t; values: 'a Map.Make(KEY)}`. The performance characteristics could relatively easily be improved by changing the linear datastructure. 
- moves exported types in `Program` shared by mli and ml files to a separate ml file.
- moves `implicit_declaration` (which defines variant constructors) into a variant of `declaration` so that everything is in one list.
- aslp frontend now puts global variable declarations at the start of the program.
- some minor resulting simplifications of `loadir.ml`