### PR TITLE
Use CCFQueue for Indexed_list

### DIFF
--- a/lib/lang/program_types.ml
+++ b/lib/lang/program_types.ml
@@ -3,12 +3,12 @@ open Types
 open Expr
 open Containers
 
-type e = Expr.BasilExpr.t
+type e = Expr.BasilExpr.t [@@deriving show]
 type proc = (Var.t, e) Procedure.t
 type bloc = (Var.t, e) Block.t
 type stmt = (Var.t, Var.t, e) Stmt.t
 type prog_spec = { rely : e list; guarantee : e list }
-type func_type = Axiom of e | Uninterpreted | Function of e
+type func_type = Axiom of e | Uninterpreted | Function of e [@@deriving show]
 
 type implicit_declaration =
   | VariantCase of {
@@ -16,20 +16,33 @@ type implicit_declaration =
       belongs_to : Types.t;
       constructor : Var.t;
     }
+[@@deriving show]
 
 type declaration =
   | Type of { binding : string; typ : Types.t }
   | Function of {
       binding : Var.t;
-      attrib : Attrib.attrib_map;
+      attrib : Attrib.attrib_map; [@opaque]
       definition : func_type;
     }  (** pure functions *)
   | Variable of {
       binding : Var.t;
-      attrib : Attrib.attrib_map;
+      attrib : Attrib.attrib_map; [@opaque]
       classification : e option;
     }
-  | Procedure of { definition : proc }
+  | Procedure of { definition : proc [@opaque] }
   | Implicit of implicit_declaration
       (** A declaration which is not explicitly present in the ir program, but
           created by another construct, e.g. type constructors. *)
+[@@deriving show]
+
+(** {1 Printers (for debugging only)} *)
+
+let show_e = show_e
+let pp_e = pp_e
+let show_func_type = show_func_type
+let pp_func_type = pp_func_type
+let show_implicit_declaration = show_implicit_declaration
+let pp_implicit_declaration = pp_implicit_declaration
+let show_declaration = show_declaration
+let pp_declaration = pp_declaration

--- a/lib/transforms/gamma_vars.ml
+++ b/lib/transforms/gamma_vars.ml
@@ -35,7 +35,7 @@ let add_globals ?(check_names = false) (add : Var.t -> bool) (p : Program.t) =
   |> Iter.fold
        (fun p (s, decl) ->
          match decl with
-         | Program_types.Variable { binding; attrib } when add binding ->
+         | Program.Variable { binding; attrib } when add binding ->
              if check_names then check_var binding;
              Program.decl_global ~attrib p (gamma_of binding)
          | _ -> p)

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -153,9 +153,18 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   (** {2 Conversions and iterators} *)
 
-  (** Builds a {!t} from the given pairs. Repeated keys use the order of the
-      first occurence and the value of the last occurence. *)
-  let of_iter m = Iter.fold (fun m (k, v) -> append k v m) empty m
+  (** Builds a {!t} from the given pairs. Keys must be unique. *)
+  let of_iter m =
+    let n = ref 0 in
+    let m =
+      Iter.fold
+        (fun m (k, v) ->
+          n := !n + 1;
+          append k v m)
+        empty m
+    in
+    if !n <> length m then invalid_arg "of_iter: had duplicated keys";
+    m
 
   let of_list m = List.to_iter m |> of_iter
 

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -20,6 +20,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   open struct
     module S = Set.Make (K)
     module M = Map.Make (K)
+
     let pp_k = Format.of_to_string K.show
   end
 
@@ -106,7 +107,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
     in
 
     let before, after =
-      FQ.take_front_while (fun k -> before k (M.find k values)) order
+      FQ.take_front_while (fun k -> not (before k (M.find k values))) order
     in
     let order = FQ.cons_l before (FQ.cons_l new_keys after) in
     { order; values = M.add_list values news }
@@ -146,7 +147,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let get_exn k { values } = M.find k values
 
   let update k f m =
-    match f (find k m) with
+    match f (find_opt k m) with
     | Some new_val -> add k new_val m
     | None -> remove k m
 

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -37,8 +37,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   let empty = { order = FQ.empty; values = M.empty }
   let singleton k v = { order = FQ.singleton k; values = M.singleton k v }
-  let cardinal m = M.cardinal m.values
-  let length m = cardinal m
+  let size m = FQ.size m.order
 
   (** {2 Inserting, updating, and removing} *)
 
@@ -163,7 +162,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
           append k v m)
         empty m
     in
-    if !n <> length m then invalid_arg "of_iter: had duplicated keys";
+    if !n <> size m then invalid_arg "of_iter: had duplicated keys";
     m
 
   let of_list m = List.to_iter m |> of_iter
@@ -190,8 +189,15 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let map f { order; values } = { order; values = M.map f values }
 
   (** In-order map with both positional index and key *)
-  let mapi f m =
-    to_iter m |> Iter.mapi (fun i (k, v) -> (k, f i k v)) |> of_iter
+  let mapi f { order; values } =
+    let f i k : _ option -> _ option = function
+      | Some v -> Some (f i k v)
+      | None -> failwith "invariant violation: key in order but not values"
+    in
+    let values =
+      FQ.to_iter order |> Iter.foldi (fun m i k -> M.update k (f i k) m) values
+    in
+    { order; values }
 
   (** Re-orders keys using a comparison function on keys. *)
   let sort_by_keys compar { order; values } =

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -27,6 +27,8 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   let empty = { order = FQ.empty; values = M.empty }
   let singleton k v = { order = FQ.singleton k; values = M.singleton k v }
+  let cardinal m = M.cardinal m.values
+  let length m = cardinal m
 
   (** [append k v m] replaces [k -> v] in m, in-place if it is already defined.
       Otherwise it is appended. This operation is the fastest insertion
@@ -35,34 +37,23 @@ module Make (K : Mtypes.ORD_TYPE) = struct
     if M.mem k values then { order; values = M.add k v values }
     else { order = FQ.snoc order k; values = M.add k v values }
 
-  let of_iter m = Iter.fold (fun m (k, v) -> append k v m) empty m
-  let of_list m = List.to_iter m |> of_iter
-
-  (** Get in-order iterator of keys *)
-  let keys { order } = FQ.to_iter order
-
-  (** Get in-order iterator of key-value pairs *)
-  let to_iter { order; values } =
-    FQ.to_iter order |> Iter.map (fun k -> (k, M.find k values))
-
-  (** Get in-order list of pairs of keys and values *)
-  let to_list m = m |> to_iter |> Iter.to_list
-
-  (** Values iterator in-order *)
-  let values m = to_iter m |> Iter.map snd
-
-  (** Values iterator out-of-order *)
-  let values_nondet { values } = M.values values
-
   (** [add k v m] replaces k -> v in m, in-place if it is already defined.
-      Otherwise it is appended. This operation is the fastest insertion
-      operation (O(1)). Identical to {!append}*)
+      Otherwise it is appended. This operation is fast (O(1)).
+
+      Identical to {!append}. *)
   let add k v m = append k v m
 
+  (** [prepend k v m] replaces k -> v in m, in-place if it is already defined.
+      Otherwise it is prepended. This operation is fast (O(1)). *)
   let prepend k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else { order = FQ.cons k order; values = M.add k v values }
 
+  (** If the key is not in the map, inserts the given key-value pair {i before}
+      the first element satisfying the given [before] predicate. If there is no
+      element satisfying the predicate, the pair is inserted at the end.
+
+      If the key was already in the map, simply updates the value in-place. *)
   let insert_before ~before k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else
@@ -72,21 +63,29 @@ module Make (K : Mtypes.ORD_TYPE) = struct
       let order = FQ.cons_l before (FQ.cons k after) in
       { order; values = M.add k v values }
 
+  (** If the key is not in the map, inserts the given key-value pair {i before}
+      the given [before] key. If [before] was not in the map, the pair is
+      inserted at the end.
+
+      If the key was already in the map, simply updates the value in-place. *)
   let insert_before_key ~before k v m =
     insert_before ~before:(fun k _ -> K.equal before k) k v m
 
-  (** Insert value at absolute index. Negative indices count inwards from the
-      end of the list, idices greater than the length append. *)
+  (** Insert value at absolute index, between [0] and {!length}[ - 1]. *)
   let insert_at_index ~before_index k v { order; values } =
+    if not (0 <= before_index && before_index < M.cardinal values) then
+      invalid_arg "insert_at_index: index out of range";
     if M.mem k values then { order; values = M.add k v values }
     else
       let before, after = FQ.take_front_l before_index order in
       let order = FQ.cons_l before (FQ.cons k after) in
       { order; values = M.add k v values }
 
-  (** Relatively efficient: cons *)
-  let append_list news m = List.fold_left (fun acc (k, v) -> add k v acc) m news
+  (** Inserts the given pairs, as a block, before the first element satisfying
+      the given [before] predicate.
 
+      If any new keys were already in the map, those keys will be updated
+      in-place. *)
   let insert_list_before ~before news { values; order } =
     (* ignore pre-existing keys and only use leftmost position of each new key. *)
     let _, new_keys =
@@ -102,7 +101,18 @@ module Make (K : Mtypes.ORD_TYPE) = struct
     let order = FQ.cons_l before (FQ.cons_l new_keys after) in
     { order; values = M.add_list values news }
 
-  (** Lookup key, throwing [Not_found] if it does not exists. *)
+  (** Appends the given pairs to the end, with same logic as {!append}. *)
+  let append_list news m =
+    List.fold_left (fun acc (k, v) -> append k v acc) m news
+
+  (** Prepends the given pairs to the beginning, with same logic as
+      {!insert_list_before}. *)
+  let prepend_list news m =
+    (* insert_list_before rather than repeatedly prepending, so duplicated keys
+       in [news] will use their first (leftmost) position rather than rightmost. *)
+    insert_list_before ~before:(fun _ _ -> true) news m
+
+  (** Lookup key, throwing [Not_found] if it does not exist. *)
   let find k { values } = M.find k values
 
   (** Lookup key, returning [Some] if it exists. O(log n) *)
@@ -135,6 +145,28 @@ module Make (K : Mtypes.ORD_TYPE) = struct
     | Some new_val -> add k new_val m
     | None -> remove k m
 
+  (** Builds a {!t} from the given pairs. Repeated pairs use the order of the
+      first occurence and the value of the last occurence. *)
+  let of_iter m = Iter.fold (fun m (k, v) -> append k v m) empty m
+
+  let of_list m = List.to_iter m |> of_iter
+
+  (** Get in-order iterator of keys *)
+  let keys { order } = FQ.to_iter order
+
+  (** Get in-order iterator of key-value pairs *)
+  let to_iter { order; values } =
+    FQ.to_iter order |> Iter.map (fun k -> (k, M.find k values))
+
+  (** Get in-order list of pairs of keys and values *)
+  let to_list m = m |> to_iter |> Iter.to_list
+
+  (** Values iterator in-order *)
+  let values m = to_iter m |> Iter.map snd
+
+  (** Values iterator out-of-order *)
+  let values_nondet { values } = M.values values
+
   (** Re-orders keys using a comparison function on keys. *)
   let sort_by_keys compar { order; values } =
     let order = order |> FQ.to_list |> List.sort compar |> FQ.of_list in
@@ -142,7 +174,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   (** Re-orders keys using a comparison function on `(key, value)`. *)
   let sort (compar : (K.t * 'a) Ord.t) { order; values } =
-    let cmp = Ord.opp (Ord.map (fun k -> (k, M.find k values)) compar) in
+    let cmp = Ord.map (fun k -> (k, M.find k values)) compar in
     let order = order |> FQ.to_list |> List.sort cmp |> FQ.of_list in
     { order; values }
 end

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -1,35 +1,49 @@
 (** Sequential and associative datastructure with fast iteration, appending, and
-    O(logn) indexing. *)
+    O(logn) indexing.
+
+    Basically, this can be used when you want an associative map but with a
+    manually-specified iteration order. *)
 
 open Containers
+open Containers.Fun
+
+open struct
+  module FQ = struct
+    include CCFQueue
+
+    (** Prepends the given list to the given queue. *)
+    let cons_l l q = List.fold_right CCFQueue.cons l q
+  end
+end
 
 module Make (K : Mtypes.ORD_TYPE) = struct
+  module S = Set.Make (K)
   module M = Map.Make (K)
 
-  (* Order stored reverse *)
-  type 'a t = { order : K.t list; values : 'a M.t }
-  (** invariant : \forall x . x \in order == x \in M.keys values *)
+  type 'a t = { order : K.t FQ.t; values : 'a M.t }
+  (** invariant : \forall x . x \in order == x \in M.keys values
 
-  let empty = { order = []; values = M.empty }
-  let singleton k v = { order = [ k ]; values = M.singleton k v }
+      [order] must be a permutation of the keys of [values]. *)
 
-  let of_iter m =
-    let m = Iter.persistent m in
-    let values = M.of_iter m in
-    (* we store in reverse order  *)
-    let order = m |> Iter.map fst |> Iter.to_rev_list in
-    (* no duplicate keys  *)
-    assert (Int.equal (M.cardinal values) (List.length order));
-    { values; order }
+  let empty = { order = FQ.empty; values = M.empty }
+  let singleton k v = { order = FQ.singleton k; values = M.singleton k v }
 
+  (** [append k v m] replaces [k -> v] in m, in-place if it is already defined.
+      Otherwise it is appended. This operation is the fastest insertion
+      operation (O(1)). *)
+  let append k v { order; values } =
+    if M.mem k values then { order; values = M.add k v values }
+    else { order = FQ.snoc order k; values = M.add k v values }
+
+  let of_iter m = Iter.fold (fun m (k, v) -> append k v m) empty m
   let of_list m = List.to_iter m |> of_iter
 
   (** Get in-order iterator of keys *)
-  let keys { order } = List.to_iter order |> Iter.rev
+  let keys { order } = FQ.to_iter order
 
   (** Get in-order iterator of key-value pairs *)
   let to_iter { order; values } =
-    List.to_iter order |> Iter.rev |> Iter.map (fun k -> (k, M.find k values))
+    FQ.to_iter order |> Iter.map (fun k -> (k, M.find k values))
 
   (** Get in-order list of pairs of keys and values *)
   let to_list m = m |> to_iter |> Iter.to_list
@@ -40,13 +54,6 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   (** Values iterator out-of-order *)
   let values_nondet { values } = M.values values
 
-  (** [append k v m] replaces k -> v in m, in-place if it is already defined.
-      Otherwise it is appended. This operation is the fastest insertion
-      operation (O(1)). *)
-  let append k v { order; values } =
-    if M.mem k values then { order; values = M.add k v values }
-    else { order = k :: order; values = M.add k v values }
-
   (** [add k v m] replaces k -> v in m, in-place if it is already defined.
       Otherwise it is appended. This operation is the fastest insertion
       operation (O(1)). Identical to {!append}*)
@@ -54,17 +61,15 @@ module Make (K : Mtypes.ORD_TYPE) = struct
 
   let prepend k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
-    else { order = order @ [ k ]; values = M.add k v values }
+    else { order = FQ.cons k order; values = M.add k v values }
 
   let insert_before ~before k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else
-      let order = List.rev order in
-      let idx =
-        List.find_index (fun k -> before k (M.find k values)) order
-        |> Option.get_or ~default:(-1)
+      let before, after =
+        FQ.take_front_while (fun k -> not (before k (M.find k values))) order
       in
-      let order = List.insert_at_idx idx k order |> List.rev in
+      let order = FQ.cons_l before (FQ.cons k after) in
       { order; values = M.add k v values }
 
   let insert_before_key ~before k v m =
@@ -75,28 +80,27 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let insert_at_index ~before_index k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else
-      let idx = List.length order - before_index in
-      let order = List.insert_at_idx idx k order in
+      let before, after = FQ.take_front_l before_index order in
+      let order = FQ.cons_l before (FQ.cons k after) in
       { order; values = M.add k v values }
 
   (** Relatively efficient: cons *)
   let append_list news m = List.fold_left (fun acc (k, v) -> add k v acc) m news
 
-  let insert_list_before ~before news m =
-    let { values; order } = m in
-    let order = List.rev order in
-    let idx =
-      List.find_index (fun k -> before k (M.find k values)) order
-      |> Option.get_or ~default:(-1)
+  let insert_list_before ~before news { values; order } =
+    (* ignore pre-existing keys and only use leftmost position of each new key. *)
+    let _, new_keys =
+      let old_keys_set = S.of_iter (Iter.map fst (M.to_iter values)) in
+      List.fold_filter_map
+        (fun seen k -> (S.add k seen, if S.mem k seen then None else Some k))
+        old_keys_set (List.map fst news)
     in
-    let add_ord =
-      List.filter (fun (id, _) -> not @@ M.mem id values) news |> List.map fst
+
+    let before, after =
+      FQ.take_front_while (fun k -> before k (M.find k values)) order
     in
-    let pre, post = List.take_drop idx order in
-    let order = List.rev @@ pre @ add_ord @ post in
-    (* update all values  *)
-    let values = List.fold_left (fun acc (k, v) -> M.add k v acc) values news in
-    { order; values }
+    let order = FQ.cons_l before (FQ.cons_l new_keys after) in
+    { order; values = M.add_list values news }
 
   (** Lookup key, throwing [Not_found] if it does not exists. *)
   let find k { values } = M.find k values
@@ -120,30 +124,25 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let remove k { order; values } =
     let values' = M.remove k values in
     let order =
-      if not @@ Equal.physical values' values then
-        List.remove_one ~eq:K.equal k order
+      if not (Equal.physical values' values) then
+        order |> FQ.to_iter |> Iter.filter (not % K.equal k) |> FQ.of_iter
       else order
     in
     { order; values = values' }
 
-  let update k f { order; values } =
-    match f (M.find_opt k values) with
-    | Some new_val -> { order; values = M.add k new_val values }
-    | None ->
-        let order = List.remove_one ~eq:K.equal k order in
-        let values = M.remove k values in
-        { order; values }
+  let update k f m =
+    match f (find k m) with
+    | Some new_val -> add k new_val m
+    | None -> remove k m
 
-  (** Sort keys: just List.sort *)
+  (** Re-orders keys using a comparison function on keys. *)
   let sort_by_keys compar { order; values } =
-    let order = List.sort (Ord.opp compar) order in
+    let order = order |> FQ.to_list |> List.sort compar |> FQ.of_list in
     { order; values }
 
-  (** less efficient sort on values; copies index *)
-  let sort (compar : (K.t * 'a) Ord.t) ({ order; values } : 'a t) =
-    let ord a b =
-      Ord.opp (Ord.map (fun k -> (k, M.find k values)) compar) a b
-    in
-    let order = List.sort ord order in
+  (** Re-orders keys using a comparison function on `(key, value)`. *)
+  let sort (compar : (K.t * 'a) Ord.t) { order; values } =
+    let cmp = Ord.opp (Ord.map (fun k -> (k, M.find k values)) compar) in
+    let order = order |> FQ.to_list |> List.sort cmp |> FQ.of_list in
     { order; values }
 end

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -122,16 +122,30 @@ module Make (K : Mtypes.ORD_TYPE) = struct
        in [news] will use their first (leftmost) position rather than rightmost. *)
     insert_list_before ~before:(fun _ _ -> true) news m
 
-  let remove k { order; values } =
-    let values' = M.remove k values in
-    let order =
-      if not (Equal.physical values' values) then
-        order |> FQ.to_iter |> Iter.filter (not % K.equal k) |> FQ.of_iter
-      else order
-    in
-    { order; values = values' }
-
   (** {2 Lookup (by key)} *)
+
+  (** Updates the given key using the given update function with type
+      ['a option -> 'a option].
+
+      The key is modified in-place if it is already defined. Otherwise, it is
+      appended. *)
+  let update k f { order; values } =
+    let remove_key q k =
+      FQ.to_iter q |> Iter.filter (not % K.equal k) |> FQ.of_iter
+    in
+    let order = ref order in
+    (* using a single M.update avoids repeating map operations. *)
+    let values =
+      values
+      |> M.update k (fun v ->
+          let v' = f v in
+          (match (v, v') with
+          | Some _, None -> order := remove_key !order k
+          | None, Some v' -> order := FQ.snoc !order k
+          | _ -> ());
+          v')
+    in
+    { order = !order; values }
 
   (** Lookup key, throwing [Not_found] if it does not exist. *)
   let find k { values } = M.find k values
@@ -145,10 +159,7 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   (** Lookup key, throwing [Not_found] if it does not exist *)
   let get_exn k { values } = M.find k values
 
-  let update k f m =
-    match f (find_opt k m) with
-    | Some new_val -> add k new_val m
-    | None -> remove k m
+  let remove k m = update k (Fun.const None) m
 
   (** {2 Conversions and iterators} *)
 
@@ -189,15 +200,12 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let map f { order; values } = { order; values = M.map f values }
 
   (** In-order map with both positional index and key *)
-  let mapi f { order; values } =
+  let mapi f m =
     let f i k : _ option -> _ option = function
       | Some v -> Some (f i k v)
       | None -> failwith "invariant violation: key in order but not values"
     in
-    let values =
-      FQ.to_iter order |> Iter.foldi (fun m i k -> M.update k (f i k) m) values
-    in
-    { order; values }
+    FQ.to_iter m.order |> Iter.foldi (fun m i k -> update k (f i k) m) m
 
   (** Re-orders keys using a comparison function on keys. *)
   let sort_by_keys compar { order; values } =

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -20,11 +20,16 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   open struct
     module S = Set.Make (K)
     module M = Map.Make (K)
+    let pp_k = Format.of_to_string K.show
   end
 
   (** {2 Basics} *)
 
-  type 'a t = { order : K.t FQ.t; values : 'a M.t }
+  type 'a t = {
+    order : K.t FQ.t; [@printer FQ.pp pp_k]
+    values : 'a M.t; [@polyprinter M.pp pp_k]
+  }
+  [@@deriving show]
   (** invariant : \forall x . x \in order == x \in M.keys values
 
       [order] must be a permutation of the keys of [values]. *)

--- a/lib/util/indexed_list.ml
+++ b/lib/util/indexed_list.ml
@@ -17,8 +17,12 @@ open struct
 end
 
 module Make (K : Mtypes.ORD_TYPE) = struct
-  module S = Set.Make (K)
-  module M = Map.Make (K)
+  open struct
+    module S = Set.Make (K)
+    module M = Map.Make (K)
+  end
+
+  (** {2 Basics} *)
 
   type 'a t = { order : K.t FQ.t; values : 'a M.t }
   (** invariant : \forall x . x \in order == x \in M.keys values
@@ -30,9 +34,10 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   let cardinal m = M.cardinal m.values
   let length m = cardinal m
 
+  (** {2 Inserting, updating, and removing} *)
+
   (** [append k v m] replaces [k -> v] in m, in-place if it is already defined.
-      Otherwise it is appended. This operation is the fastest insertion
-      operation (O(1)). *)
+      Otherwise it is appended. This operation is fast (O(1)). *)
   let append k v { order; values } =
     if M.mem k values then { order; values = M.add k v values }
     else { order = FQ.snoc order k; values = M.add k v values }
@@ -112,6 +117,17 @@ module Make (K : Mtypes.ORD_TYPE) = struct
        in [news] will use their first (leftmost) position rather than rightmost. *)
     insert_list_before ~before:(fun _ _ -> true) news m
 
+  let remove k { order; values } =
+    let values' = M.remove k values in
+    let order =
+      if not (Equal.physical values' values) then
+        order |> FQ.to_iter |> Iter.filter (not % K.equal k) |> FQ.of_iter
+      else order
+    in
+    { order; values = values' }
+
+  (** {2 Lookup (by key)} *)
+
   (** Lookup key, throwing [Not_found] if it does not exist. *)
   let find k { values } = M.find k values
 
@@ -124,28 +140,14 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   (** Lookup key, throwing [Not_found] if it does not exist *)
   let get_exn k { values } = M.find k values
 
-  (** Out-of-order map *)
-  let map f { order; values } = { order; values = M.map f values }
-
-  (** In-order map with both positional index and key *)
-  let mapi f m =
-    to_iter m |> Iter.mapi (fun ind (k, v) -> (k, f ind k v)) |> of_iter
-
-  let remove k { order; values } =
-    let values' = M.remove k values in
-    let order =
-      if not (Equal.physical values' values) then
-        order |> FQ.to_iter |> Iter.filter (not % K.equal k) |> FQ.of_iter
-      else order
-    in
-    { order; values = values' }
-
   let update k f m =
     match f (find k m) with
     | Some new_val -> add k new_val m
     | None -> remove k m
 
-  (** Builds a {!t} from the given pairs. Repeated pairs use the order of the
+  (** {2 Conversions and iterators} *)
+
+  (** Builds a {!t} from the given pairs. Repeated keys use the order of the
       first occurence and the value of the last occurence. *)
   let of_iter m = Iter.fold (fun m (k, v) -> append k v m) empty m
 
@@ -167,14 +169,26 @@ module Make (K : Mtypes.ORD_TYPE) = struct
   (** Values iterator out-of-order *)
   let values_nondet { values } = M.values values
 
+  (** {2 Mapping and sorting} *)
+
+  (** Out-of-order map *)
+  let map f { order; values } = { order; values = M.map f values }
+
+  (** In-order map with both positional index and key *)
+  let mapi f m =
+    to_iter m |> Iter.mapi (fun i (k, v) -> (k, f i k v)) |> of_iter
+
   (** Re-orders keys using a comparison function on keys. *)
   let sort_by_keys compar { order; values } =
     let order = order |> FQ.to_list |> List.sort compar |> FQ.of_list in
     { order; values }
 
-  (** Re-orders keys using a comparison function on `(key, value)`. *)
-  let sort (compar : (K.t * 'a) Ord.t) { order; values } =
-    let cmp = Ord.map (fun k -> (k, M.find k values)) compar in
-    let order = order |> FQ.to_list |> List.sort cmp |> FQ.of_list in
+  (** Re-orders keys using a comparison function on [(key, value)]. *)
+  let sort (cmp : (K.t * 'a) Ord.t) { order; values } =
+    let order =
+      order |> FQ.to_list
+      |> List.map (fun k -> (k, M.find k values))
+      |> List.sort cmp |> List.map fst |> FQ.of_list
+    in
     { order; values }
 end

--- a/test/test_util_indexlist.ml
+++ b/test/test_util_indexlist.ml
@@ -111,5 +111,6 @@ open Containers
 let%expect_test "invalid from list" =
   match CCResult.guard_str (fun () -> M.of_list [ (1, 31); (1, 32) ]) with
   | Ok _ -> print_endline "ok"
-  | Error e -> print_endline e;
-  [%expect {| Invalid_argument("of_iter: had duplicated keys") |}]
+  | Error e ->
+      print_endline e;
+      [%expect {| Invalid_argument("of_iter: had duplicated keys") |}]

--- a/test/test_util_indexlist.ml
+++ b/test/test_util_indexlist.ml
@@ -109,9 +109,7 @@ let%expect_test "empty" =
 open Containers
 
 let%expect_test "invalid from list" =
-  try
-    let m = M.of_list [ (1, 31); (1, 32) ] in
-    pr "remove nonexistent" m
-  with Assert_failure _ ->
-    print_endline "assert failure";
-    [%expect {| assert failure |}]
+  match CCResult.guard_str (fun () -> M.of_list [ (1, 31); (1, 32) ]) with
+  | Ok _ -> print_endline "ok"
+  | Error e -> print_endline e;
+  [%expect {| Invalid_argument("of_iter: had duplicated keys") |}]


### PR DESCRIPTION
This changes the Indexed_list data structure to use a [CCFQueue](https://uq-pac.github.io/bincaml/containers-data/containers-data/CCFQueue/index.html) because it has faster append on both ends (amortised O(1)) and not worse insertion in the middle (linear). More importantly, it also means that the order does not have to be stored in a reversed list order which uses index-based slicing.

Along the way, I have added printers for debugging and odoc comments that clarify some edge cases.

I have also found and fixed some bugs where `insert_at_index` did not do what the comment said for out of bounds indices (now simply asserted against) and where `update` would lead to an incomplete order when the `f` function returns Some for a key which was previously None.

Related https://github.com/UQ-PAC/bincaml/pull/236 https://github.com/UQ-PAC/bincaml/issues/235