### PR TITLE
Capstone Nix and Dune minimise/fix

### DIFF
--- a/capstone_arm64_disas.opam
+++ b/capstone_arm64_disas.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "dune" {>= "3.24"}
   "ocaml"
-  "ppx_expect"
   "odoc" {with-doc}
 ]
 build: [

--- a/capstone_arm64_disas.opam
+++ b/capstone_arm64_disas.opam
@@ -37,4 +37,5 @@ depexts: [
   ["capstone"] {os = "macos" & os-distribution = "homebrew"}
   ["capstone"] {os = "freebsd"}
   ["capstone"] {os-distribution = "nixos"}
+  ["capstone"] {os-family = "arch"}
 ]

--- a/capstone_arm64_disas.opam.template
+++ b/capstone_arm64_disas.opam.template
@@ -6,4 +6,5 @@ depexts: [
   ["capstone"] {os = "macos" & os-distribution = "homebrew"}
   ["capstone"] {os = "freebsd"}
   ["capstone"] {os-distribution = "nixos"}
+  ["capstone"] {os-family = "arch"}
 ]

--- a/capstone_arm64_disas/Makefile
+++ b/capstone_arm64_disas/Makefile
@@ -1,2 +1,0 @@
-test1: test.c
-	gcc test.c -lcapstone -o test1

--- a/capstone_arm64_disas/capstone.ml
+++ b/capstone_arm64_disas/capstone.ml
@@ -7,25 +7,3 @@ let disas_arm64_op (opcode : Int32.t) : (string, string) result =
   Bytes.set_int32_le bytes 0 opcode;
   let b = String.of_bytes bytes in
   try Ok (disas_arm64_op_ffi b) with Failure m -> Error m
-
-let%expect_test "invalid" =
-  Result.iter_error print_endline (disas_arm64_op @@ Int32.of_int 0x123444);
-  [%expect {| capstone disassembly error |}]
-
-let%expect_test "invalid" =
-  try print_endline (disas_arm64_op_ffi "ab")
-  with Failure m ->
-    print_endline m;
-    [%expect {| disas requries 4-byte buffer |}]
-
-let%expect_test "disas add" =
-  Result.iter print_endline (disas_arm64_op @@ Int32.of_int 0x8b031041);
-  [%expect {| add x1, x2, x3, lsl #4 |}]
-
-let%expect_test "dsas stp" =
-  Result.iter print_endline (disas_arm64_op @@ Int32.of_int 0xa9bf7bf0);
-  [%expect {| stp x16, x30, [sp, #-0x10]! |}]
-
-let%expect_test "disas ldrb" =
-  Result.iter print_endline (disas_arm64_op (Int32.of_int 0x3940a260));
-  [%expect {| ldrb w0, [x19, #0x28] |}]

--- a/capstone_arm64_disas/dune
+++ b/capstone_arm64_disas/dune
@@ -2,10 +2,12 @@
  (target includes.gen)
  (enabled_if
   (= %{system} "macosx"))
+ (deps capst.c)
  (action
   (with-stdout-to
    includes.gen
-   (system "sh -c \"printf \\\"%s/include\\\" $(brew --prefix)\""))))
+   (system
+    "if cc -E capst.c >/dev/null; then echo '()'; else echo $(brew --prefix)/include; fi"))))
 
 (rule
  (target includes.gen)

--- a/capstone_arm64_disas/dune
+++ b/capstone_arm64_disas/dune
@@ -1,18 +1,21 @@
 (rule
  (target includes.gen)
  (enabled_if
-  (= %{system} "macosx"))
- (deps capst.c)
+  (and
+   (= %{system} "macosx")
+   %{bin-available:brew}))
  (action
   (with-stdout-to
    includes.gen
-   (system
-    "if cc -E capst.c >/dev/null; then echo '()'; else echo $(brew --prefix)/include; fi"))))
+   (bash "echo $(brew --prefix)/include"))))
 
 (rule
  (target includes.gen)
  (enabled_if
-  (<> %{system} "macosx"))
+  (not
+   (and
+    (= %{system} "macosx")
+    %{bin-available:brew})))
  (action
   (with-stdout-to
    includes.gen

--- a/capstone_arm64_disas/dune
+++ b/capstone_arm64_disas/dune
@@ -19,12 +19,15 @@
 (library
  (public_name capstone_arm64_disas)
  (name capstone)
+ (modules capstone)
  (foreign_stubs
   (language c)
   (include_dirs
    (include includes.gen))
   (names capst))
- (c_library_flags -lcapstone)
- (inline_tests)
- (preprocess
-  (pps ppx_expect)))
+ (c_library_flags -lcapstone))
+
+(test
+ (name test_capstone)
+ (modules test_capstone)
+ (libraries capstone))

--- a/capstone_arm64_disas/test_capstone.ml
+++ b/capstone_arm64_disas/test_capstone.ml
@@ -1,0 +1,16 @@
+let () =
+  assert (
+    Capstone.disas_arm64_op (Int32.of_int 0x123444)
+    = Error "capstone disassembly error");
+
+  assert (
+    Capstone.disas_arm64_op (Int32.of_int 0x8b031041)
+    = Ok "add x1, x2, x3, lsl #4");
+
+  assert (
+    Capstone.disas_arm64_op (Int32.of_int 0xa9bf7bf0)
+    = Ok "stp x16, x30, [sp, #-0x10]!");
+
+  assert (
+    Capstone.disas_arm64_op (Int32.of_int 0x3940a260)
+    = Ok "ldrb w0, [x19, #0x28]")

--- a/dune-project
+++ b/dune-project
@@ -25,10 +25,7 @@
 (package
  (name capstone_arm64_disas)
  (synopsis "Disas arm ops with capstone")
- (depends
-   ocaml
-   ppx_expect
-   )
+ (depends ocaml)
 )
 
 (package

--- a/nix/capstone_arm64_disas.nix
+++ b/nix/capstone_arm64_disas.nix
@@ -6,6 +6,7 @@
   capstone,
 
   # ocaml packages
+  ocaml
 
   # test:
 
@@ -22,7 +23,7 @@ buildDunePackage {
 
   checkInputs = [ ];
   nativeBuildInputs = [ writableTmpDirAsHomeHook ];
-  buildInputs = [ ];
+  buildInputs = [ ocaml ];
   propagatedBuildInputs = [ capstone ];
 
   doCheck = false;

--- a/nix/capstone_arm64_disas.nix
+++ b/nix/capstone_arm64_disas.nix
@@ -6,14 +6,6 @@
   capstone,
 
   # ocaml packages
-  logs,
-  fmt,
-  iter,
-  linol,
-  linol-lwt,
-  containers,
-  ppx_deriving,
-  ppx_expect,
 
   # test:
 
@@ -30,16 +22,7 @@ buildDunePackage {
 
   checkInputs = [ ];
   nativeBuildInputs = [ writableTmpDirAsHomeHook ];
-  buildInputs = [
-    logs
-    fmt
-    iter
-    linol
-    linol-lwt
-    containers
-    ppx_deriving
-    ppx_expect
-  ];
+  buildInputs = [ ];
   propagatedBuildInputs = [ capstone ];
 
   doCheck = false;


### PR DESCRIPTION
Each commit is basically self-describing.

The last commit, in particular, is needed to fix building `nix build .#capstone_arm64_disas` in Nix on MacOS.