### PR TITLE
nix(docs): patch `odoc-driver` to fix source links, add sherlodoc www

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig.extra-substituters = [ "https://pac-nix.cachix.org/" ];
+  nixConfig.extra-trusted-public-keys = [
+    "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc="
+  ];
+
   inputs = {
     self.submodules = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,4 @@
 {
-  nixConfig.extra-substituters = [ "https://pac-nix.cachix.org/" ];
-  nixConfig.extra-trusted-public-keys = [
-    "pac-nix.cachix.org-1:l29Pc2zYR5yZyfSzk1v17uEZkhEw0gI4cXuOIsxIGpc="
-  ];
-
   inputs = {
     self.submodules = true;
 

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -9,10 +9,10 @@ lib.makeScope newScope (
     callPackage = self.callPackage;
   in
   {
-    blah = callPackage (
+    test_package_for_odoc_include_subdirs = callPackage (
       { dune, buildDunePackage }:
-      buildDunePackage {
-        pname = "blah";
+      buildDunePackage (self: {
+        pname = "test_package_for_odoc_include_subdirs";
         version = "0.0";
         src = dune.src;
 
@@ -22,13 +22,13 @@ lib.makeScope newScope (
 
           dune describe
 
-          echo '
-          (name blah)
-          (package (name blah))
-          ' >> dune-project
-          substituteInPlace lib/dune --replace-fail 'library' 'library (public_name blah.foolib)'
+          echo "
+          (name ${self.pname})
+          (package (name ${self.pname}))
+          " >> dune-project
+          substituteInPlace lib/dune --replace-fail 'library' "library (public_name ${self.pname}.foolib)"
         '';
-      }
+      })
     ) { };
 
     /**
@@ -49,7 +49,6 @@ lib.makeScope newScope (
         bincaml_lsp,
         yojson_2,
         bos,
-        blah,
       }:
       (buildEnv {
         name = "fake-dune-prefix-for-odoc";

--- a/nix/bincaml-docs.nix
+++ b/nix/bincaml-docs.nix
@@ -9,6 +9,28 @@ lib.makeScope newScope (
     callPackage = self.callPackage;
   in
   {
+    blah = callPackage (
+      { dune, buildDunePackage }:
+      buildDunePackage {
+        pname = "blah";
+        version = "0.0";
+        src = dune.src;
+
+        preBuild = ''
+          rm -rf dune-project
+          cd test/blackbox-tests/test-cases/include-qualified/basic.t
+
+          dune describe
+
+          echo '
+          (name blah)
+          (package (name blah))
+          ' >> dune-project
+          substituteInPlace lib/dune --replace-fail 'library' 'library (public_name blah.foolib)'
+        '';
+      }
+    ) { };
+
     /**
       Usually, `odoc_driver` uses opam to discover packages, but we don't have
       a real opam switch in Nix. Fortunately, `odoc_driver` also has the ability
@@ -27,6 +49,7 @@ lib.makeScope newScope (
         bincaml_lsp,
         yojson_2,
         bos,
+        blah,
       }:
       (buildEnv {
         name = "fake-dune-prefix-for-odoc";
@@ -96,8 +119,6 @@ lib.makeScope newScope (
         fake_dune_prefix,
         ocaml,
         findlib,
-        odoc_3_2, # FIXME: use a wrapper instead of `odoc` on path
-        sherlodoc,
         odoc-driver,
       }:
       stdenvNoCC.mkDerivation {
@@ -109,9 +130,7 @@ lib.makeScope newScope (
         nativeBuildInputs = [
           ocaml
           findlib
-          odoc_3_2
           odoc-driver
-          sherlodoc
           fake_opam
           fake_dune_prefix
         ];
@@ -123,6 +142,7 @@ lib.makeScope newScope (
 
         buildPhase = ''
           source activate_fake_dune_prefix.sh
+          export OCAMLRUNPARAM=b
           odoc_driver \
             --html-dir=$out \
             --mld-dir=$dev --odoc-dir=$dev --odocl-dir=$dev \
@@ -139,6 +159,69 @@ lib.makeScope newScope (
             echo "stdlib index.html missing. stdlib links are probably broken."
             exit 1
           }
+        '';
+      }
+    ) { };
+
+    db = callPackage (
+      {
+        stdenvNoCC,
+        sherlodoc,
+        writeText,
+        src,
+      }:
+      stdenvNoCC.mkDerivation {
+        name = "bincaml-sherlodoc-db";
+
+        src = src;
+        doCheck = true;
+
+        nativeBuildInputs = [ sherlodoc ];
+
+        buildPhase = ''
+          mkdir -p $out/bin
+          export SHERLODOC_DB=$out/sherlodoc.marshal
+          for d in $src/*; do
+            if [[ -d $d ]]; then
+              found="$(find $d -name '*.odocl' -not -name '*__*' -not -name 'impl-*' -not -name page-index.odocl)"
+              if [[ -n "$found" ]]; then
+                printf "$(basename $d)\t%s\n" $found >> file-list
+              fi
+            fi
+          done
+
+          sherlodoc index --file-list file-list
+
+          cat <<EOF > $out/bin/activate_sherlodoc_db.sh
+          export SHERLODOC_DB=$SHERLODOC_DB
+          EOF
+          chmod +x $out/bin/*
+        '';
+
+        checkPhase = ''
+          echo "Testing sherlodoc search..."
+          sherlodoc search Format.formatter | grep 'type Stdlib.Format.formatter'
+        '';
+      }
+    ) { src = self.docs.dev; };
+
+    serve = callPackage (
+      {
+        sherlodoc,
+        docs,
+        writeShellApplication,
+        db,
+      }:
+      writeShellApplication {
+        name = "sherlodoc-serve-bincaml";
+        runtimeInputs = [
+          sherlodoc
+          db
+        ];
+        derivationArgs.checkPhase = "";
+        text = ''
+          source activate_sherlodoc_db.sh
+          exec sherlodoc serve "$@"
         '';
       }
     ) { };

--- a/nix/odoc-driver.nix
+++ b/nix/odoc-driver.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  makeWrapper,
   buildDunePackage,
 
   odoc,
@@ -23,7 +24,10 @@ buildDunePackage {
   pname = "odoc-driver";
   inherit (odoc) version src;
 
-  nativeBuildInputs = [ sherlodoc ];
+  nativeBuildInputs = [
+    sherlodoc
+    makeWrapper
+  ];
   buildInputs = [
     odoc
     odoc-md
@@ -51,6 +55,10 @@ buildDunePackage {
   nativeCheckInputs = [ ];
   checkInputs = [ ];
   doCheck = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/odoc_driver --prefix PATH : ${lib.makeBinPath [ odoc sherlodoc ]}
+  '';
 
   meta = {
     description = "OCaml Documentation Generator - Driver";

--- a/nix/odoc.nix
+++ b/nix/odoc.nix
@@ -1,10 +1,10 @@
 /**
   Patches `ocamlPackages.odoc` to fix its dependency specification and enable use
-  as a library. Also update the version to fix failing cmdliner tests.
+  as a library. Also update the version to fix `include_subdirs` issues.
 */
 {
   odoc,
-  fetchurl,
+  fetchFromGitHub,
   cmdliner,
   ppx_expect,
 }:
@@ -14,10 +14,14 @@
 }).overrideAttrs
   (
     _: prev: {
-      version = "3.2.1";
-      src = fetchurl {
-        url = "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz";
-        hash = "sha256-1F6xJVFIOf2awncCu0k40bTztpeOmxarlnPqBnJFr/w=";
+      version = "3.2.1-patched";
+
+      # fixing https://github.com/ocaml/odoc/issues/1475
+      src = fetchFromGitHub {
+        owner = "rsc-s";
+        repo = "odoc";
+        rev = "bd961999c1e24332c26066fe63244092e143b254";
+        hash = "sha256-UDD1o1jaSJadiNmPW98vM2FukbzNDWrlXjdcy8KDPfo=";
       };
 
       propagatedBuildInputs =

--- a/nix/sherlodoc.nix
+++ b/nix/sherlodoc.nix
@@ -1,5 +1,7 @@
 {
   lib,
+  makeWrapper,
+  fetchFromGitHub,
   buildDunePackage,
   writableTmpDirAsHomeHook,
 
@@ -20,6 +22,18 @@
   base,
   alcotest,
   findlib,
+  crunch,
+  cppo,
+  dream,
+
+  enableWww ? true,
+  # Restores `sherlodoc/www` folder. https://github.com/ocaml/odoc/issues/1441
+  sherlodoc-www-src ? fetchFromGitHub {
+    owner = "mt-caret";
+    repo = "odoc";
+    rev = "426bb50b0679ee3bb69f974141ab4a6797587c2c";
+    hash = "sha256-1lzggOwpIBaBHAFKeAMscA+UEB1F4G7DR3Om3rllyzI=";
+  }
 }:
 
 buildDunePackage (self: {
@@ -30,6 +44,10 @@ buildDunePackage (self: {
     menhir
     js_of_ocaml
     writableTmpDirAsHomeHook
+    makeWrapper
+  ] ++ lib.optionals enableWww [
+    cppo
+    crunch
   ];
 
   buildInputs = [
@@ -46,6 +64,8 @@ buildDunePackage (self: {
     tyxml
     base
     alcotest
+  ] ++ lib.optionals enableWww [
+    dream
   ];
 
   nativeCheckInputs = [
@@ -55,6 +75,11 @@ buildDunePackage (self: {
   ];
   checkInputs = [ alcotest ];
   doCheck = true;
+
+  postPatch = lib.optionalString enableWww ''
+    cp -r ${sherlodoc-www-src}/sherlodoc/www sherlodoc/www
+    substituteInPlace sherlodoc/www/dune --replace-fail '(optional)' ""
+  '';
 
   preCheck = ''
     substituteInPlace sherlodoc/test/dune --replace-quiet --quiet ""
@@ -70,10 +95,15 @@ buildDunePackage (self: {
        )))
     EOF
 
-    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no
+    opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no --no-setup
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/sherlodoc --set PATH ${lib.makeBinPath [ odoc ]}
   '';
 
   meta = {
+    mainProgram = "sherlodoc";
     description = "Search engine for OCaml documentation";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.katrinafyi ];


### PR DESCRIPTION
this patches odoc to work towards fixing this issue: https://www.github.com/ocaml/odoc/issues/1475. `blah` is a test package which uses `include_subdirs` to check that the source linking works.

this is the bug in current docs where the "Source" link doesn't work https://uq-pac.github.io/bincaml/bincaml/bincaml.transforms/Transforms/index.html#module-Aslp
<img width="939" height="473" alt="image" src="https://github.com/user-attachments/assets/a58146f6-1696-4e0e-a0c8-1189a78b8827" />



primarily, changes src for `odoc-driver` package and changes it to be a wrapped program with direct references to sherlodoc and odoc. this means that users of `odoc-driver` do not need to manually make sure that those are on their path and they all have compatible versions.

changes sherlodoc package to add a flag for `enableWww` which aims to bring back `sherlodoc serve` support for hosting a local version of https://doc.sherlocode.com/. this is there but not used yet, as it still needs a lot of work. a lot of things are hard-coded to ocaml.org.

