### PR TITLE
dune: add ocamlformat version, add odoc-driver, add lsp

### DIFF
--- a/bincaml.opam
+++ b/bincaml.opam
@@ -43,9 +43,9 @@ depends: [
   "stb_image"
   "kittyimg"
   "terminal_size"
-  "ocamlformat" {with-dev-setup}
-  "odig" {with-dev-setup}
-  "sherlodoc" {with-doc}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
   "ppx_expect"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -64,9 +64,9 @@
   stb_image
   kittyimg
   terminal_size
-  (ocamlformat :with-dev-setup)
-  (odig :with-dev-setup)
-  (sherlodoc :with-doc)
+  (ocamlformat (and (= 0.29.0) :with-dev-setup))
+  (ocaml-lsp-server :with-dev-setup)
+  (odoc-driver :with-doc)
   ppx_expect
   (alcotest :with-test))
  (tags (program-analysis)))


### PR DESCRIPTION
in future, this could mean avoiding the need to write these manually in workflows.

this is especially important for ocamlformat which is specified in https://github.com/UQ-PAC/bincaml/blob/main/.ocamlformat 