### PR TITLE
PSTATE flag abstraction

### DIFF
--- a/lib/analysis/sp.ml
+++ b/lib/analysis/sp.ml
@@ -261,5 +261,5 @@ proc @branching(a:bv64) -> (b:bv64) [
           booland(eq(a_1:bv64, a:bv64), bvult(a_1:bv64, 0x64:bv64),
            eq(a_2:bv64, a_1:bv64), boolnot(bvult(a_2:bv64, 0x32:bv64)),
            eq(x_1:bv64, 0x0:bv64))), eq(x_3:bv64, x_2:bv64))), eq(b:bv64, x_3:bv64)),
-      false, false))
+      false))
     |}]

--- a/lib/gtirb/gtirb.ml
+++ b/lib/gtirb/gtirb.ml
@@ -48,9 +48,9 @@ let chop_block_opcodes ~(need_flip : bool) block : block option =
   let open Option in
   let contents size () =
     if Bytes.length block.raw = 0 then String.empty
-    else
-      (*Logs.debug (fun m -> m "%d : %d" (Bytes.length block.raw) size);*)
-      String.of_bytes @@ Bytes.sub block.raw block.block.offset size
+    else (
+      Logs.debug (fun m -> m "%d : %d" (Bytes.length block.raw) size);
+      String.of_bytes @@ Bytes.sub block.raw block.block.offset size)
   in
   (* all blocks that have uuid defined  *)
   let* uuid, size, opcodes, contents =

--- a/lib/gtirb/gtirb.ml
+++ b/lib/gtirb/gtirb.ml
@@ -48,9 +48,9 @@ let chop_block_opcodes ~(need_flip : bool) block : block option =
   let open Option in
   let contents size () =
     if Bytes.length block.raw = 0 then String.empty
-    else (
-      Logs.debug (fun m -> m "%d : %d" (Bytes.length block.raw) size);
-      String.of_bytes @@ Bytes.sub block.raw block.block.offset size)
+    else
+      (*Logs.debug (fun m -> m "%d : %d" (Bytes.length block.raw) size);*)
+      String.of_bytes @@ Bytes.sub block.raw block.block.offset size
   in
   (* all blocks that have uuid defined  *)
   let* uuid, size, opcodes, contents =

--- a/lib/lang/algsimp.ml
+++ b/lib/lang/algsimp.ml
@@ -310,6 +310,21 @@ let algebraic_simplifications
       replace [%here] arg
   | UnaryExpr { op = `BoolNOT; arg = UnaryExpr { op = `BoolNOT; arg }, _ } ->
       replace [%here] arg
+  | UnaryExpr { op = `SignExtend k; arg = UnaryExpr { op = `BVNOT; arg }, _ } ->
+      replace [%here]
+        (BasilExpr.unexp ~op:`BVNOT
+           (BasilExpr.sign_extend ~n_prefix_bits:k arg))
+  (* bvadd(x, not(y), 1) = bvsub(x, y) *)
+  | ApplyIntrin
+      {
+        op = `BVADD;
+        args = [ (a, _); (UnaryExpr { op = `BVNOT; arg = b }, _); (k, _) ];
+      }
+    when is_bvone k ->
+      replace [%here] (BasilExpr.binexp ~op:`BVSUB (fix a) b)
+  | BinaryExpr { op = `EQ; arg1 = a, _; arg2 = b, _ }
+    when BasilExpr.equal (fix a) (fix b) ->
+      replace [%here] (BasilExpr.boolconst true)
   | _ -> Keep
 
 let algebraic_simplifications = sequence drop_assoc algebraic_simplifications
@@ -322,8 +337,9 @@ let alg_simp_rewriter ?visit e =
   e
   |> ( to_steady BasilExpr.equal @@ fun e ->
        e |> partial_eval_expr |> simp_concat_fix )
-  |> to_steady BasilExpr.equal
-       (BasilExpr.rewrite_typed_two ?visit algebraic_simplifications)
+  |> to_steady BasilExpr.equal (fun e ->
+      e |> partial_eval_expr
+      |> BasilExpr.rewrite_typed_two ?visit algebraic_simplifications)
   |> to_steady BasilExpr.equal (BasilExpr.rewrite_typed_two ?visit normalise)
 
 let normalise e =

--- a/lib/lang/algsimp.ml
+++ b/lib/lang/algsimp.ml
@@ -99,6 +99,7 @@ let normalise e =
   | UnaryExpr { op = `BoolNOT; arg = ApplyIntrin { op = `OR; args } } ->
       replace [%here]
         (BasilExpr.applyintrin ~op:`AND (List.map BasilExpr.boolnot args))
+      (*
   | ApplyIntrin
       {
         attrib;
@@ -110,6 +111,7 @@ let normalise e =
       replace [%here]
         (BasilExpr.binexp ~attrib ~op:`BVSUB (fix v)
            (BasilExpr.bvconst ~attrib:cattrib (Bitvec.neg i)))
+        *)
   | _ -> Keep
 
 let simplify_concat

--- a/lib/lang/algsimp.ml
+++ b/lib/lang/algsimp.ml
@@ -99,19 +99,6 @@ let normalise e =
   | UnaryExpr { op = `BoolNOT; arg = ApplyIntrin { op = `OR; args } } ->
       replace [%here]
         (BasilExpr.applyintrin ~op:`AND (List.map BasilExpr.boolnot args))
-      (*
-  | ApplyIntrin
-      {
-        attrib;
-        op = `BVADD;
-        args =
-          [ (RVar _ as v); Constant { attrib = cattrib; const = `Bitvector i } ];
-      }
-    when Bitvec.is_negative i ->
-      replace [%here]
-        (BasilExpr.binexp ~attrib ~op:`BVSUB (fix v)
-           (BasilExpr.bvconst ~attrib:cattrib (Bitvec.neg i)))
-        *)
   | _ -> Keep
 
 let simplify_concat
@@ -316,7 +303,6 @@ let algebraic_simplifications
       replace [%here]
         (BasilExpr.unexp ~op:`BVNOT
            (BasilExpr.sign_extend ~n_prefix_bits:k arg))
-  (* bvadd(x, not(y), 1) = bvsub(x, y) *)
   | ApplyIntrin
       {
         op = `BVADD;

--- a/lib/lang/algsimp.ml
+++ b/lib/lang/algsimp.ml
@@ -327,6 +327,20 @@ let algebraic_simplifications
   | BinaryExpr { op = `EQ; arg1 = a, _; arg2 = b, _ }
     when BasilExpr.equal (fix a) (fix b) ->
       replace [%here] (BasilExpr.boolconst true)
+  | BinaryExpr
+      {
+        op = `EQ;
+        arg1 = a, _;
+        arg2 =
+          ( ApplyIntrin
+              {
+                op = `BVADD;
+                args = [ b; E (Constant { const = `Bitvector c }) ];
+              },
+            _ );
+      }
+    when BasilExpr.equal (fix a) b && not (is_zero c) ->
+      replace [%here] (BasilExpr.boolconst false)
   | _ -> Keep
 
 let algebraic_simplifications = sequence drop_assoc algebraic_simplifications

--- a/lib/lang/algsimp.ml
+++ b/lib/lang/algsimp.ml
@@ -344,9 +344,32 @@ let alg_simp_rewriter ?visit e =
       |> BasilExpr.rewrite_typed_two ?visit algebraic_simplifications)
   |> to_steady BasilExpr.equal (BasilExpr.rewrite_typed_two ?visit normalise)
 
-let normalise e =
-  let e = alg_simp_rewriter e in
-  BasilExpr.rewrite_typed_two normalise e
+let normalise ?visit e =
+  let e = alg_simp_rewriter ?visit e in
+  BasilExpr.rewrite_typed_two ?visit normalise e
+
+(** Simplifications for making ir more readable but interfere with analysis *)
+let readable e =
+  let open AbstractExpr in
+  let open BasilExpr in
+  let open Bitvec in
+  let e = AbstractExpr.map fst e in
+  match e with
+  | ApplyIntrin
+      {
+        attrib;
+        op = `BVADD;
+        args =
+          [ (RVar _ as v); Constant { attrib = cattrib; const = `Bitvector i } ];
+      }
+    when Bitvec.is_negative i ->
+      replace [%here]
+        (BasilExpr.binexp ~attrib ~op:`BVSUB (fix v)
+           (BasilExpr.bvconst ~attrib:cattrib (Bitvec.neg i)))
+  | _ -> Keep
+
+let readable ?visit e =
+  normalise ?visit e |> BasilExpr.rewrite_typed_two ?visit readable
 
 let%expect_test "normalise" =
   let e =

--- a/lib/lang/expr.ml
+++ b/lib/lang/expr.ml
@@ -409,7 +409,7 @@ module BasilExpr = struct
   let fold_with_type (alg : 'e abstract_expr -> 'a) = zygo_l ~cata type_alg alg
   let fold_with_type_r (alg : 'e abstract_expr -> 'a) = zygo ~cata type_alg alg
 
-  let elabourate_typ e =
+  let elaborate_typ e =
     fold_with_type
       (fun t ->
         let typ = type_alg (AbstractExpr.map snd t) in

--- a/lib/lang/expr.ml
+++ b/lib/lang/expr.ml
@@ -36,6 +36,9 @@ module BasilExpr = struct
   (** create fixed type from abstract type *)
   let fix i = E i
 
+  let fix2 i = fix (AbstractExpr.map fix i)
+  let fix3 i = fix (AbstractExpr.map fix2 i)
+
   (** create abstract type from fixed type *)
   let unfix i = match i with E i -> i
 

--- a/lib/lang/expr_eval.ml
+++ b/lib/lang/expr_eval.ml
@@ -88,15 +88,42 @@ let eval_expr_alg (e : Ops.AllOps.const option BasilExpr.abstract_expr) =
   | ApplyIntrin { op = #Ops.Spec.intrin } -> None
   | ApplyIntrin { op = #Ops.Maps.intrin } -> None
 
-let partial_eval_alg (e : BasilExpr.t BasilExpr.abstract_expr) :
-    BasilExpr.rewrite =
+let const_eval_expr (e : BasilExpr.t BasilExpr.abstract_expr) :
+    BasilExpr.t option =
   let open AbstractExpr in
   let open Option.Infix in
   let is_const e =
     match BasilExpr.unfix e with Constant { const } -> Some const | _ -> None
   in
-  let e = AbstractExpr.map is_const e in
-  eval_expr_alg e >|= BasilExpr.const |> BasilExpr.replace_opt
+  let e' = AbstractExpr.map is_const e in
+  eval_expr_alg e' >|= BasilExpr.const
+
+let partial_eval_intrin (e : BasilExpr.t BasilExpr.abstract_expr) :
+    BasilExpr.t option =
+  let open AbstractExpr in
+  match e with
+  | ApplyIntrin { op; args } ->
+      let consts, rest =
+        List.partition
+          (function Constant _ -> true | _ -> false)
+          (List.map BasilExpr.unfix args)
+        |> Pair.map_same (List.map BasilExpr.fix)
+      in
+      if List.length consts >= 2 then
+        let e_const =
+          BasilExpr.applyintrin ~op consts
+          |> BasilExpr.unfix |> const_eval_expr
+          |> Option.get_exn_or "terms should all be constant"
+        in
+        Some (BasilExpr.applyintrin ~op (List.append rest [ e_const ]))
+      else None
+  | _ -> None
+
+let partial_eval_alg (e : BasilExpr.t BasilExpr.abstract_expr) :
+    BasilExpr.rewrite =
+  const_eval_expr e
+  |> Option.or_lazy ~else_:(fun _ -> partial_eval_intrin e)
+  |> BasilExpr.replace_opt
 
 let partial_eval_expr e = BasilExpr.rewrite ~rw_fun:partial_eval_alg e
 let eval_expr e = BasilExpr.cata eval_expr_alg e

--- a/lib/lang/expr_eval.ml
+++ b/lib/lang/expr_eval.ml
@@ -105,9 +105,8 @@ let partial_eval_intrin (e : BasilExpr.t BasilExpr.abstract_expr) :
   | ApplyIntrin { op; args } when Ops.AllOps.is_commutative_intrin op ->
       let consts, rest =
         List.partition
-          (function Constant _ -> true | _ -> false)
-          (List.map BasilExpr.unfix args)
-        |> Pair.map_same (List.map BasilExpr.fix)
+          (function BasilExpr.E (Constant _) -> true | _ -> false)
+          args
       in
       if List.length consts >= 2 then
         let e_const =

--- a/lib/lang/expr_eval.ml
+++ b/lib/lang/expr_eval.ml
@@ -102,7 +102,7 @@ let partial_eval_intrin (e : BasilExpr.t BasilExpr.abstract_expr) :
     BasilExpr.t option =
   let open AbstractExpr in
   match e with
-  | ApplyIntrin { op; args } ->
+  | ApplyIntrin { op; args } when Ops.AllOps.is_commutative_intrin op ->
       let consts, rest =
         List.partition
           (function Constant _ -> true | _ -> false)

--- a/lib/lang/ops.ml
+++ b/lib/lang/ops.ml
@@ -459,6 +459,11 @@ module AllOps = struct
           return (Bitvector w)
     | `MapUpdate -> return @@ List.hd args
 
+  let is_commutative_intrin (o : intrin) =
+    match o with
+    | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND | `OR | `AND -> true
+    | `Cases | `BVConcat | `MapUpdate -> false
+
   (** ops returning booleans *)
 
   let rec to_string (op : [< const | unary | binary | intrin | lambda ]) =

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -247,6 +247,14 @@ module PassManager = struct
       invariants = Invariants.presupposes [];
     }
 
+  let branch_conditions =
+    {
+      name = "branch-conditions";
+      apply = Proc Transforms.Branch_conditions.transform;
+      doc = "TODO";
+      invariants = Invariants.presupposes [];
+    }
+
   let irreducible_loop =
     {
       name = "irreducible-loops";
@@ -469,6 +477,7 @@ module PassManager = struct
       remove_unreachable_blocks;
       collapse_empty_blocks;
       cleanup_cfg;
+      branch_conditions;
       dfg_bool;
       dfg_ival_wint_product;
       demo_ival_wint_dfg;

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -375,6 +375,17 @@ module PassManager = struct
       invariants = Invariants.presupposes [];
     }
 
+  let readable_exprs =
+    {
+      name = "readable-expressions";
+      apply = Proc Transforms.Cf_tx.simplify_proc_exprs_readable_default;
+      doc =
+        "Perform intra-expression simplifications and constant folding for \
+         whole program. Includes simplifications that aid readability at the \
+         detrement of some analyses.";
+      invariants = Invariants.presupposes [];
+    }
+
   let inter_dead =
     {
       name = "inter-dead-store-elim";
@@ -502,6 +513,7 @@ module PassManager = struct
       intra_function_summaries;
       inter_function_summaries;
       cf_exprs;
+      readable_exprs;
       inter_dead;
       linear_const;
       linear_copy;

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -251,7 +251,9 @@ module PassManager = struct
     {
       name = "branch-conditions";
       apply = Proc Transforms.Branch_conditions.transform;
-      doc = "TODO";
+      doc =
+        "(incomplete) Rewrites branch conditions to be in terms of numerical \
+         comparisons instead of flags.";
       invariants = Invariants.presupposes [];
     }
 

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -17,13 +17,14 @@ module FlagSemantics = struct
         (** Carry when subtracting first from second *)
     | CarryBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Carry when adding first and second *)
-    | NegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | ZeroNegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** When left == -right (or -left == right) *)
-    | Equal of Expr.BasilExpr.t * Expr.BasilExpr.t  (** When left == right *)
-    | IsZero of Expr.BasilExpr.t  (** When expr is zero *)
-    | Slt of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | ZeroEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** When left == right *)
+    | ZeroIsZero of Expr.BasilExpr.t  (** When expr is zero *)
+    | NegSlt of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** When left < right signed *)
-    | IsNeg of Expr.BasilExpr.t  (** When expr is negative *)
+    | NegIsNeg of Expr.BasilExpr.t  (** When expr is negative *)
   [@@deriving show { with_path = false }]
 
   let extract_semantics e =
@@ -194,17 +195,17 @@ module FlagSemantics = struct
               { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
             Constant { const = `Bitvector bv2 } )
           when Bitvec.is_zero bv2 ->
-            Some (Equal (fix a, bvconst (Bitvec.neg bv)))
+            Some (ZeroEqual (fix a, bvconst (Bitvec.neg bv)))
         | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
             Constant { const = `Bitvector bv } )
           when Bitvec.is_zero bv ->
-            Some (NegEqual (fix a, fix b))
+            Some (ZeroNegEqual (fix a, fix b))
         | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
             Constant { const = `Bitvector bv } )
           when Bitvec.is_zero bv ->
-            Some (Equal (fix a, fix b))
+            Some (ZeroEqual (fix a, fix b))
         | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
-            Some (IsZero (fix2 a))
+            Some (ZeroIsZero (fix2 a))
         | _ -> None)
     | UnaryExpr
         {
@@ -214,16 +215,16 @@ module FlagSemantics = struct
               { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] };
         }
       when e1 = e2 + 1 ->
-        Some (Slt (fix a, bvconst (Bitvec.neg bv)))
+        Some (NegSlt (fix a, bvconst (Bitvec.neg bv)))
     | UnaryExpr
         {
           op = `Extract (e1, e2);
           arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
         }
       when e1 = e2 + 1 ->
-        Some (Slt (fix a, fix b))
+        Some (NegSlt (fix a, fix b))
     | UnaryExpr { op = `Extract (e1, e2); arg } when e1 = e2 + 1 ->
-        Some (IsNeg (fix2 arg))
+        Some (NegIsNeg (fix2 arg))
     | _ -> None
 end
 
@@ -331,10 +332,10 @@ proc @main() -> ()
      $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
        0xffffffff:bv32), 0x1:bv32));
 
-     $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
-     $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
-     $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };
-     $PSTATE_N:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_N = "Never" };
+     $PSTATE_V:bv1 := 0x0:bv1;
+     $PSTATE_C:bv1 := 0x0:bv1;
+     $PSTATE_Z:bv1 := 0x1:bv1;
+     $PSTATE_N:bv1 := 0x0:bv1;
 
     goto (%ret);
   ];
@@ -401,16 +402,16 @@ prog entry @main;
             bvadd(zero_extend(32, $H2),
              zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CarryBySum ($H2, $H3))" };
          $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2,
-            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(NegEqual ($H2, $H3))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Equal (extract(32,0, $R0), 0xffffffff:bv32))" };
+            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroNegEqual ($H2, $H3))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroEqual (extract(32,0, $R0), 0xffffffff:bv32))" };
          $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
-           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Equal (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(Slt (extract(32,0, $R0), 0xffffffff:bv32))" };
+           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegSlt (extract(32,0, $R0), 0xffffffff:bv32))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(Slt (extract(32,0, $R0), extract(32,0, $R1)))" };
+           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(IsNeg extract(32,0, $R0))" };
+           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegIsNeg extract(32,0, $R0))" };
          $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
          $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
          $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -370,49 +370,49 @@ prog entry @main;
        block %main [
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (extract(32,0, $R0), 0x1:bv32))" };
+            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0x1:bv32))" };
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
             bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
+             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(bvadd(extract(32,0, $R0),
               bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
             bvadd(bvadd(sign_extend(32, extract(32,0, $R0)),
               sign_extend(32,
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))),
             bvadd(sign_extend(32, local_31:bv32),
-             sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (local_31:bv32, local_32:bv32))" };
+             sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OBySum (local_31:bv32, local_32:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryBySum (extract(32,0, $R0), 0x1:bv32))" };
+            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0x1:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
             bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
+             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(bvadd(extract(32,0, $R0),
               bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
             bvadd(bvadd(zero_extend(32, extract(32,0, $R0)),
               zero_extend(32,
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))),
             bvadd(zero_extend(32, $H2),
-             zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CarryBySum ($H2, $H3))" };
+             zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CBySum ($H2, $H3))" };
          $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2,
-            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroNegEqual ($H2, $H3))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroEqual (extract(32,0, $R0), 0xffffffff:bv32))" };
+            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZNegEqual ($H2, $H3))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), 0xffffffff:bv32))" };
          $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
-           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZeroEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegSlt (extract(32,0, $R0), 0xffffffff:bv32))" };
+           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), 0xffffffff:bv32))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
+           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegIsNeg extract(32,0, $R0))" };
+           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NIsNeg extract(32,0, $R0))" };
          $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
          $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
            bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -236,7 +236,17 @@ let annotate_flag_assigns stmt =
   | Instr_Assign { attrib; al } ->
       let annotations =
         List.filter_map
-          (fun (v, e) -> extract_semantics e |> Option.map (fun s -> (v, s)))
+          (fun (v, e) ->
+            let o = extract_semantics e in
+            if
+              Option.is_none o
+              && String.starts_with ~prefix:"$PSTATE_" (Var.name v)
+            then
+              Logs.debug (fun m ->
+                  m "%s had no assiged semantic meaning for expr %s"
+                    (Var.name v)
+                    (Expr.BasilExpr.to_string (Algsimp.normalise e)));
+            o |> Option.map (fun s -> (v, s)))
           al
       in
       let attrib =

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -365,11 +365,11 @@ prog entry @main;
        block %main [
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByConst (extract(32,0, $R0), 0x1:bv32))" };
+            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (extract(32,0, $R0), 0x1:bv32))" };
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
             bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByConst (extract(32,0, $R0), 0xfffffffe:bv32))" };
+             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
          $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
             bvadd(bvadd(extract(32,0, $R0),
               bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
@@ -382,11 +382,11 @@ prog entry @main;
              sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (local_31:bv32, local_32:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByConst (extract(32,0, $R0), 0x1:bv32))" };
+            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryBySum (extract(32,0, $R0), 0x1:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
             bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByConst (extract(32,0, $R0), 0xfffffffe:bv32))" };
+             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
          $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
             bvadd(bvadd(extract(32,0, $R0),
               bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -5,21 +5,15 @@ module FlagSemantics = struct
   type t =
     | Never
     | Always
-    | OByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** Overflow when subtracting first from second *)
-    | OBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** Overflow when adding first and second *)
-    | CByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** Carry when subtracting first from second *)
-    | CBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** Carry when adding first and second *)
-    | ZNegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** When left == -right (or -left == right) *)
-    | ZEqual of Expr.BasilExpr.t * Expr.BasilExpr.t  (** When left == right *)
-    | ZIsZero of Expr.BasilExpr.t  (** When expr is zero *)
-    | NSlt of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** When left < right signed *)
-    | NIsNeg of Expr.BasilExpr.t  (** When expr is negative *)
+    | O of computation  (** Overflow from computation *)
+    | C of computation  (** Carry from computation *)
+    | Z of computation  (** When computation is zero *)
+    | N of computation  (** When computation is negative *)
+
+  and computation =
+    | Sum of Expr.BasilExpr.t * Expr.BasilExpr.t  (** Computed e1 + e2 *)
+    | Diff of Expr.BasilExpr.t * Expr.BasilExpr.t  (** Computed e1 - e2 *)
+    | Expr of Expr.BasilExpr.t  (** The result of evaluating an expr *)
   [@@deriving show { with_path = false }]
 
   let extract_overflow_cary arg1 arg2 =
@@ -55,7 +49,9 @@ module FlagSemantics = struct
               ];
           } )
       when s1 = s2 && s1 > 0 && equal (fix a) (fix c) && sext_eq s1 bv1 bv2 ->
-        Some (OBySum (fix a, bvconst bv1))
+        if Bitvec.is_negative bv1 then
+          Some (O (Diff (fix a, bvconst (Bitvec.neg bv1))))
+        else Some (O (Sum (fix a, bvconst bv1)))
     | ( UnaryExpr
           {
             op = `SignExtend s1;
@@ -73,7 +69,7 @@ module FlagSemantics = struct
       when s1 = s2 && s2 = s3 && s1 > 0
            && equal (fix a) (fix c)
            && equal (fix b) (fix d) ->
-        Some (OBySum (fix a, fix b))
+        Some (O (Sum (fix a, fix b)))
     | ( UnaryExpr
           {
             op = `SignExtend s1;
@@ -88,7 +84,7 @@ module FlagSemantics = struct
       when s1 = s2 && s2 = s3 && s1 > 0
            && equal (fix a) (fix c)
            && equal (fix b) (fix d) ->
-        Some (OByDiff (fix a, fix b))
+        Some (O (Diff (fix a, fix b)))
     | ( UnaryExpr
           {
             op = `ZeroExtend z1;
@@ -109,7 +105,9 @@ module FlagSemantics = struct
               ];
           } )
       when z1 = z2 && z1 > 0 && equal (fix a) (fix c) && zext_eq z1 bv1 bv2 ->
-        Some (CBySum (fix a, bvconst bv1))
+        if Bitvec.is_negative bv1 then
+          Some (C (Diff (fix a, bvconst (Bitvec.neg bv1))))
+        else Some (O (Sum (fix a, bvconst bv1)))
     | ( UnaryExpr
           {
             op = `ZeroExtend z1;
@@ -127,7 +125,7 @@ module FlagSemantics = struct
       when z1 = z2 && z2 = z3 && z1 > 0
            && equal (fix a) (fix c)
            && equal (fix b) (fix d) ->
-        Some (CBySum (fix a, fix b))
+        Some (C (Sum (fix a, fix b)))
     | ( UnaryExpr
           {
             op = `ZeroExtend z1;
@@ -151,28 +149,20 @@ module FlagSemantics = struct
            && equal (fix a) (fix c)
            && equal (fix b) d
            && is_one bv ->
-        Some (CByDiff (fix a, fix b))
+        Some (C (Diff (fix a, fix b)))
     | _ -> None
 
-  let extract_zero arg1 arg2 =
+  let extract_expr arg =
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
-    let is_zero = function
-      | Constant { const = `Bitvector bv } -> Bitvec.is_zero bv
-      | _ -> false
-    in
-    match (unfix2 arg1, unfix2 arg2) with
-    | ( ApplyIntrin
-          { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
-        c )
-      when is_zero c ->
-        Some (ZEqual (fix a, bvconst (Bitvec.neg bv)))
-    | ApplyIntrin { op = `BVADD; args = [ a; b ] }, c when is_zero c ->
-        Some (ZNegEqual (fix a, fix b))
-    | BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b }, c when is_zero c ->
-        Some (ZEqual (fix a, fix b))
-    | a, c when is_zero c -> Some (ZIsZero (fix2 a))
-    | _ -> None
+    match unfix2 arg with
+    | ApplyIntrin
+        { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] } ->
+        if Bitvec.is_negative bv then Diff (fix a, bvconst (Bitvec.neg bv))
+        else Sum (fix a, bvconst bv)
+    | ApplyIntrin { op = `BVADD; args = [ a; b ] } -> Sum (fix a, fix b)
+    | BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b } -> Diff (fix a, fix b)
+    | a -> Expr (fix2 a)
 
   let extract_semantics e =
     let e = Algsimp.normalise e in
@@ -197,28 +187,17 @@ module FlagSemantics = struct
               { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
         } ->
         extract_overflow_cary arg1 arg2
-    | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
-      ->
-        extract_zero (fix arg1) (fix arg2)
     | UnaryExpr
         {
-          op = `Extract ex;
+          op = `BOOLTOBV1;
           arg =
-            ApplyIntrin
-              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] }
-            as arg;
+            BinaryExpr
+              { op = `EQ; arg1; arg2 = Constant { const = `Bitvector bv } };
         }
-      when is_msb (fix2 arg) ex ->
-        Some (NSlt (fix a, bvconst (Bitvec.neg bv)))
-    | UnaryExpr
-        {
-          op = `Extract ex;
-          arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b } as arg;
-        }
-      when is_msb (fix2 arg) ex ->
-        Some (NSlt (fix a, fix b))
+      when Bitvec.is_zero bv ->
+        Some (Z (extract_expr (fix arg1)))
     | UnaryExpr { op = `Extract ex; arg } when is_msb (fix2 arg) ex ->
-        Some (NIsNeg (fix2 arg))
+        Some (N (extract_expr (fix2 arg)))
     | _ -> None
 end
 
@@ -334,20 +313,20 @@ prog entry @main;
 
     [
        block %main [
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0x1:bv32))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), sign_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))), bvadd(sign_extend(32, local_31:bv32), sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OBySum (local_31:bv32, local_32:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0x1:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), zero_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))), bvadd(zero_extend(32, $H2), zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CBySum ($H2, $H3))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZNegEqual ($H2, $H3))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), 0xffffffff:bv32))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), 0xffffffff:bv32))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NIsNeg extract(32,0, $R0))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(O (Sum (extract(32,0, $R0), 0x1:bv32)))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(O (Diff (extract(32,0, $R0), 0x2:bv32)))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), sign_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(O (Diff (extract(32,0, $R0), extract(32,0, $R1))))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))), bvadd(sign_extend(32, local_31:bv32), sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(O (Sum (local_31:bv32, local_32:bv32)))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(O (Sum (extract(32,0, $R0), 0x1:bv32)))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(C (Diff (extract(32,0, $R0), 0x2:bv32)))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), zero_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(C (Diff (extract(32,0, $R0), extract(32,0, $R1))))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))), bvadd(zero_extend(32, $H2), zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(C (Sum ($H2, $H3)))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Z (Sum ($H2, $H3)))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Z (Sum (extract(32,0, $R0), 0x1:bv32)))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Z (Diff (extract(32,0, $R0), extract(32,0, $R1))))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(N (Sum (extract(32,0, $R0), 0x1:bv32)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(N (Diff (extract(32,0, $R0), extract(32,0, $R1))))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(N (Expr extract(32,0, $R0)))" };
          $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
          $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
          $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32));

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -207,8 +207,10 @@ let annotate_flag_assigns stmt =
   match stmt with
   | Instr_Assign { attrib; al } ->
       let annotations =
-        List.filter_map
-          (fun (v, e) ->
+        al
+        |> List.filter (fun (v, _) ->
+            Types.equal (Var.typ v) (Types.Bitvector 1))
+        |> List.filter_map (fun (v, e) ->
             let o = FlagSemantics.extract_semantics e in
             if
               Option.is_none o
@@ -219,7 +221,6 @@ let annotate_flag_assigns stmt =
                     (Var.name v)
                     (Expr.BasilExpr.to_string (Algsimp.normalise e)));
             o |> Option.map (fun s -> (v, s)))
-          al
       in
       let attrib =
         List.fold_left

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -1,11 +1,6 @@
 open Bincaml_util.Common
 open Lang
 
-(* instead of rewriting shapes, we should perform an analysis that assigns to each flag+codepoint an abstract value corresponding to its semantic meaning! Then we can rewrite assumes with the semantic meaning!
-   For soundness, delete terms of the analysis value map whenever a variable present in the map is assigned to.
-   This should not lose any precision since branch conditions should only occur directly after flag assignment!
- *)
-
 module FlagSemantics = struct
   type t =
     | Never

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -5,14 +5,10 @@ module FlagSemantics = struct
   type t =
     | Never
     | Always
-    | OverflowByConst of Expr.BasilExpr.t * Bitvec.t
-        (** Overflow when adding expr and const *)
     | OverflowByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Overflow when subtracting first from second *)
     | OverflowBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Overflow when adding first and second *)
-    | CarryByConst of Expr.BasilExpr.t * Bitvec.t
-        (** Carry when adding expr and const *)
     | CarryByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Carry when subtracting first from second *)
     | CarryBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
@@ -82,7 +78,7 @@ module FlagSemantics = struct
                && equal (fix a) (fix c)
                && k2 = k1 + s1
                && sext_eq s1 bv1 bv2 ->
-            Some (OverflowByConst (fix a, bv1))
+            Some (OverflowBySum (fix a, bvconst bv1))
         | ( UnaryExpr
               {
                 op = `SignExtend s1;
@@ -144,7 +140,7 @@ module FlagSemantics = struct
                && equal (fix a) (fix c)
                && k2 = k1 + s1
                && zext_eq s1 bv1 bv2 ->
-            Some (CarryByConst (fix a, bv1))
+            Some (CarryBySum (fix a, bvconst bv1))
         | ( UnaryExpr
               {
                 op = `ZeroExtend z1;

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -23,8 +23,8 @@ module FlagSemantics = struct
     | NegIsNeg of Expr.BasilExpr.t  (** When expr is negative *)
   [@@deriving show { with_path = false }]
 
-  let extract_semantics e =
-    let e = Algsimp.normalise e in
+  let extract_overflow_cary arg1 arg2 =
+    let open Types in
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
     let equal e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
@@ -35,6 +35,160 @@ module FlagSemantics = struct
       Bitvec.(equal (zero_extend ~extension bv1) bv2)
     in
     let is_one bv = Bitvec.(equal bv (one ~size:(size bv))) in
+    match (arg1, arg2) with
+    | ( UnaryExpr
+          {
+            op = `SignExtend s1;
+            arg =
+              ApplyIntrin
+                {
+                  op = `BVADD;
+                  args =
+                    [
+                      a; Constant { const = `Bitvector bv1; typ = Bitvector k1 };
+                    ];
+                };
+          },
+        ApplyIntrin
+          {
+            op = `BVADD;
+            args =
+              [
+                UnaryExpr { op = `SignExtend s2; arg = c };
+                Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+              ];
+          } )
+      when s1 = s2 && s1 > 0
+           && equal (fix a) (fix c)
+           && k2 = k1 + s1
+           && sext_eq s1 bv1 bv2 ->
+        Some (OverflowBySum (fix a, bvconst bv1))
+    | ( UnaryExpr
+          {
+            op = `SignExtend s1;
+            arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+          },
+        ApplyIntrin
+          {
+            op = `BVADD;
+            args =
+              [
+                UnaryExpr { op = `SignExtend s2; arg = c };
+                UnaryExpr { op = `SignExtend s3; arg = d };
+              ];
+          } )
+      when s1 = s2 && s2 = s3 && equal (fix a) (fix c) && equal (fix b) (fix d)
+      ->
+        Some (OverflowBySum (fix a, fix b))
+    | ( UnaryExpr
+          {
+            op = `SignExtend s1;
+            arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+          },
+        BinaryExpr
+          {
+            op = `BVSUB;
+            arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
+            arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
+          } )
+      when s1 = s2 && s2 = s3 && equal (fix a) (fix c) && equal (fix b) (fix d)
+      ->
+        Some (OverflowByDiff (fix a, fix b))
+    | ( UnaryExpr
+          {
+            op = `ZeroExtend s1;
+            arg =
+              ApplyIntrin
+                {
+                  op = `BVADD;
+                  args =
+                    [
+                      a; Constant { const = `Bitvector bv1; typ = Bitvector k1 };
+                    ];
+                };
+          },
+        ApplyIntrin
+          {
+            op = `BVADD;
+            args =
+              [
+                UnaryExpr { op = `ZeroExtend s2; arg = c };
+                Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+              ];
+          } )
+      when s1 = s2 && s1 > 0
+           && equal (fix a) (fix c)
+           && k2 = k1 + s1
+           && zext_eq s1 bv1 bv2 ->
+        Some (CarryBySum (fix a, bvconst bv1))
+    | ( UnaryExpr
+          {
+            op = `ZeroExtend z1;
+            arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+          },
+        ApplyIntrin
+          {
+            op = `BVADD;
+            args =
+              [
+                UnaryExpr { op = `ZeroExtend z2; arg = c };
+                UnaryExpr { op = `ZeroExtend z3; arg = d };
+              ];
+          } )
+      when z1 = z2 && z2 = z3 && equal (fix a) (fix c) && equal (fix b) (fix d)
+      ->
+        Some (CarryBySum (fix a, fix b))
+    | ( UnaryExpr
+          {
+            op = `ZeroExtend z1;
+            arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+          },
+        ApplyIntrin
+          {
+            op = `BVADD;
+            args =
+              [
+                UnaryExpr { op = `ZeroExtend z2; arg = c };
+                UnaryExpr
+                  {
+                    op = `ZeroExtend z3;
+                    arg = UnaryExpr { op = `BVNOT; arg = d };
+                  };
+                Constant { const = `Bitvector bv };
+              ];
+          } )
+      when z1 = z2 && z2 = z3
+           && equal (fix a) (fix c)
+           && equal (fix b) d
+           && is_one bv ->
+        Some (CarryByDiff (fix a, fix b))
+    | _ -> None
+
+  let extract_zero arg1 arg2 =
+    let open Expr.AbstractExpr in
+    let open Expr.BasilExpr in
+    match (arg1, arg2) with
+    | ( ApplyIntrin
+          { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
+        Constant { const = `Bitvector bv2 } )
+      when Bitvec.is_zero bv2 ->
+        Some (ZeroEqual (fix a, bvconst (Bitvec.neg bv)))
+    | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
+        Constant { const = `Bitvector bv } )
+      when Bitvec.is_zero bv ->
+        Some (ZeroNegEqual (fix a, fix b))
+    | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
+        Constant { const = `Bitvector bv } )
+      when Bitvec.is_zero bv ->
+        Some (ZeroEqual (fix a, fix b))
+    | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
+        Some (ZeroIsZero (fix2 a))
+    | _ -> None
+
+  let extract_semantics e =
+    let e = Algsimp.normalise e in
+    let open Expr.AbstractExpr in
+    let open Expr.BasilExpr in
     match unfix3 e with
     | Constant { const = `Bitvector k }
       when Bitvec.equal k (Bitvec.zero ~size:1) ->
@@ -48,178 +202,40 @@ module FlagSemantics = struct
           arg =
             UnaryExpr
               { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
-        } -> (
-        match (unfix3 arg1, unfix3 arg2) with
-        | ( UnaryExpr
-              {
-                op = `SignExtend s1;
-                arg =
-                  ApplyIntrin
-                    {
-                      op = `BVADD;
-                      args =
-                        [
-                          a;
-                          Constant
-                            { const = `Bitvector bv1; typ = Bitvector k1 };
-                        ];
-                    };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `SignExtend s2; arg = c };
-                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                  ];
-              } )
-          when s1 = s2 && s1 > 0
-               && equal (fix a) (fix c)
-               && k2 = k1 + s1
-               && sext_eq s1 bv1 bv2 ->
-            Some (OverflowBySum (fix a, bvconst bv1))
-        | ( UnaryExpr
-              {
-                op = `SignExtend s1;
-                arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `SignExtend s2; arg = c };
-                    UnaryExpr { op = `SignExtend s3; arg = d };
-                  ];
-              } )
-          when s1 = s2 && s2 = s3
-               && equal (fix a) (fix c)
-               && equal (fix b) (fix d) ->
-            Some (OverflowBySum (fix a, fix b))
-        | ( UnaryExpr
-              {
-                op = `SignExtend s1;
-                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-              },
-            BinaryExpr
-              {
-                op = `BVSUB;
-                arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
-                arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
-              } )
-          when s1 = s2 && s2 = s3
-               && equal (fix a) (fix c)
-               && equal (fix b) (fix d) ->
-            Some (OverflowByDiff (fix a, fix b))
-        | ( UnaryExpr
-              {
-                op = `ZeroExtend s1;
-                arg =
-                  ApplyIntrin
-                    {
-                      op = `BVADD;
-                      args =
-                        [
-                          a;
-                          Constant
-                            { const = `Bitvector bv1; typ = Bitvector k1 };
-                        ];
-                    };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `ZeroExtend s2; arg = c };
-                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                  ];
-              } )
-          when s1 = s2 && s1 > 0
-               && equal (fix a) (fix c)
-               && k2 = k1 + s1
-               && zext_eq s1 bv1 bv2 ->
-            Some (CarryBySum (fix a, bvconst bv1))
-        | ( UnaryExpr
-              {
-                op = `ZeroExtend z1;
-                arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `ZeroExtend z2; arg = c };
-                    UnaryExpr { op = `ZeroExtend z3; arg = d };
-                  ];
-              } )
-          when z1 = z2 && z2 = z3
-               && equal (fix a) (fix c)
-               && equal (fix b) (fix d) ->
-            Some (CarryBySum (fix a, fix b))
-        | ( UnaryExpr
-              {
-                op = `ZeroExtend z1;
-                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `ZeroExtend z2; arg = c };
-                    UnaryExpr
-                      {
-                        op = `ZeroExtend z3;
-                        arg = UnaryExpr { op = `BVNOT; arg = d };
-                      };
-                    Constant { const = `Bitvector bv };
-                  ];
-              } )
-          when z1 = z2 && z2 = z3
-               && equal (fix a) (fix c)
-               && equal (fix b) d
-               && is_one bv ->
-            Some (CarryByDiff (fix a, fix b))
-        | _ -> None)
+        } ->
+        extract_overflow_cary (unfix3 arg1) (unfix3 arg2)
     | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
-      -> (
-        match (unfix2 @@ fix arg1, unfix2 @@ fix arg2) with
-        | ( ApplyIntrin
-              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
-            Constant { const = `Bitvector bv2 } )
-          when Bitvec.is_zero bv2 ->
-            Some (ZeroEqual (fix a, bvconst (Bitvec.neg bv)))
-        | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
-            Constant { const = `Bitvector bv } )
-          when Bitvec.is_zero bv ->
-            Some (ZeroNegEqual (fix a, fix b))
-        | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
-            Constant { const = `Bitvector bv } )
-          when Bitvec.is_zero bv ->
-            Some (ZeroEqual (fix a, fix b))
-        | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
-            Some (ZeroIsZero (fix2 a))
-        | _ -> None)
+      ->
+        extract_zero (unfix2 @@ fix arg1) (unfix2 @@ fix arg2)
+    (* OOPS need to check e1 = length of bitvectors *)
     | UnaryExpr
         {
           op = `Extract (e1, e2);
           arg =
             ApplyIntrin
-              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] };
+              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] }
+            as arg;
         }
-      when e1 = e2 + 1 ->
+      when e1 = e2 + 1
+           && Option.equal ( = )
+                (Types.bit_width @@ type_of (fix2 arg))
+                (Some e1) ->
         Some (NegSlt (fix a, bvconst (Bitvec.neg bv)))
     | UnaryExpr
         {
           op = `Extract (e1, e2);
-          arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+          arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b } as arg;
         }
-      when e1 = e2 + 1 ->
+      when e1 = e2 + 1
+           && Option.equal ( = )
+                (Types.bit_width @@ type_of (fix2 arg))
+                (Some e1) ->
         Some (NegSlt (fix a, fix b))
-    | UnaryExpr { op = `Extract (e1, e2); arg } when e1 = e2 + 1 ->
+    | UnaryExpr { op = `Extract (e1, e2); arg }
+      when e1 = e2 + 1
+           && Option.equal ( = )
+                (Types.bit_width @@ type_of (fix2 arg))
+                (Some e1) ->
         Some (NegIsNeg (fix2 arg))
     | _ -> None
 end
@@ -328,6 +344,13 @@ proc @main() -> ()
      $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
        0xffffffff:bv32), 0x1:bv32));
 
+     // should not be annotated!
+     $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
+       bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
+       0xffffffff:bv32), 0x1:bv32));
+
      $PSTATE_V:bv1 := 0x0:bv1;
      $PSTATE_C:bv1 := 0x0:bv1;
      $PSTATE_Z:bv1 := 0x1:bv1;
@@ -408,6 +431,11 @@ prog entry @main;
            bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
            0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NegIsNeg extract(32,0, $R0))" };
+         $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
+         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
+           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
+           0xffffffff:bv32), 0x1:bv32));
          $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
          $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
          $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -5,22 +5,21 @@ module FlagSemantics = struct
   type t =
     | Never
     | Always
-    | OverflowByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | OByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Overflow when subtracting first from second *)
-    | OverflowBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | OBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Overflow when adding first and second *)
-    | CarryByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | CByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Carry when subtracting first from second *)
-    | CarryBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | CBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Carry when adding first and second *)
-    | ZeroNegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | ZNegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** When left == -right (or -left == right) *)
-    | ZeroEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
-        (** When left == right *)
-    | ZeroIsZero of Expr.BasilExpr.t  (** When expr is zero *)
-    | NegSlt of Expr.BasilExpr.t * Expr.BasilExpr.t
+    | ZEqual of Expr.BasilExpr.t * Expr.BasilExpr.t  (** When left == right *)
+    | ZIsZero of Expr.BasilExpr.t  (** When expr is zero *)
+    | NSlt of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** When left < right signed *)
-    | NegIsNeg of Expr.BasilExpr.t  (** When expr is negative *)
+    | NIsNeg of Expr.BasilExpr.t  (** When expr is negative *)
   [@@deriving show { with_path = false }]
 
   let extract_overflow_cary arg1 arg2 =
@@ -43,10 +42,7 @@ module FlagSemantics = struct
               ApplyIntrin
                 {
                   op = `BVADD;
-                  args =
-                    [
-                      a; Constant { const = `Bitvector bv1; typ = Bitvector k1 };
-                    ];
+                  args = [ a; Constant { const = `Bitvector bv1 } ];
                 };
           },
         ApplyIntrin
@@ -55,14 +51,11 @@ module FlagSemantics = struct
             args =
               [
                 UnaryExpr { op = `SignExtend s2; arg = c };
-                Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                Constant { const = `Bitvector bv2 };
               ];
           } )
-      when s1 = s2 && s1 > 0
-           && equal (fix a) (fix c)
-           && k2 = k1 + s1
-           && sext_eq s1 bv1 bv2 ->
-        Some (OverflowBySum (fix a, bvconst bv1))
+      when s1 = s2 && s1 > 0 && equal (fix a) (fix c) && sext_eq s1 bv1 bv2 ->
+        Some (OBySum (fix a, bvconst bv1))
     | ( UnaryExpr
           {
             op = `SignExtend s1;
@@ -77,9 +70,10 @@ module FlagSemantics = struct
                 UnaryExpr { op = `SignExtend s3; arg = d };
               ];
           } )
-      when s1 = s2 && s2 = s3 && equal (fix a) (fix c) && equal (fix b) (fix d)
-      ->
-        Some (OverflowBySum (fix a, fix b))
+      when s1 = s2 && s2 = s3 && s1 > 0
+           && equal (fix a) (fix c)
+           && equal (fix b) (fix d) ->
+        Some (OBySum (fix a, fix b))
     | ( UnaryExpr
           {
             op = `SignExtend s1;
@@ -91,20 +85,18 @@ module FlagSemantics = struct
             arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
             arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
           } )
-      when s1 = s2 && s2 = s3 && equal (fix a) (fix c) && equal (fix b) (fix d)
-      ->
-        Some (OverflowByDiff (fix a, fix b))
+      when s1 = s2 && s2 = s3 && s1 > 0
+           && equal (fix a) (fix c)
+           && equal (fix b) (fix d) ->
+        Some (OByDiff (fix a, fix b))
     | ( UnaryExpr
           {
-            op = `ZeroExtend s1;
+            op = `ZeroExtend z1;
             arg =
               ApplyIntrin
                 {
                   op = `BVADD;
-                  args =
-                    [
-                      a; Constant { const = `Bitvector bv1; typ = Bitvector k1 };
-                    ];
+                  args = [ a; Constant { const = `Bitvector bv1 } ];
                 };
           },
         ApplyIntrin
@@ -112,15 +104,12 @@ module FlagSemantics = struct
             op = `BVADD;
             args =
               [
-                UnaryExpr { op = `ZeroExtend s2; arg = c };
-                Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                UnaryExpr { op = `ZeroExtend z2; arg = c };
+                Constant { const = `Bitvector bv2 };
               ];
           } )
-      when s1 = s2 && s1 > 0
-           && equal (fix a) (fix c)
-           && k2 = k1 + s1
-           && zext_eq s1 bv1 bv2 ->
-        Some (CarryBySum (fix a, bvconst bv1))
+      when z1 = z2 && z1 > 0 && equal (fix a) (fix c) && zext_eq z1 bv1 bv2 ->
+        Some (CBySum (fix a, bvconst bv1))
     | ( UnaryExpr
           {
             op = `ZeroExtend z1;
@@ -135,9 +124,10 @@ module FlagSemantics = struct
                 UnaryExpr { op = `ZeroExtend z3; arg = d };
               ];
           } )
-      when z1 = z2 && z2 = z3 && equal (fix a) (fix c) && equal (fix b) (fix d)
-      ->
-        Some (CarryBySum (fix a, fix b))
+      when z1 = z2 && z2 = z3 && z1 > 0
+           && equal (fix a) (fix c)
+           && equal (fix b) (fix d) ->
+        Some (CBySum (fix a, fix b))
     | ( UnaryExpr
           {
             op = `ZeroExtend z1;
@@ -157,38 +147,40 @@ module FlagSemantics = struct
                 Constant { const = `Bitvector bv };
               ];
           } )
-      when z1 = z2 && z2 = z3
+      when z1 = z2 && z2 = z3 && z1 > 0
            && equal (fix a) (fix c)
            && equal (fix b) d
            && is_one bv ->
-        Some (CarryByDiff (fix a, fix b))
+        Some (CByDiff (fix a, fix b))
     | _ -> None
 
   let extract_zero arg1 arg2 =
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
+    let is_zero = function
+      | Constant { const = `Bitvector bv } -> Bitvec.is_zero bv
+      | _ -> false
+    in
     match (arg1, arg2) with
     | ( ApplyIntrin
           { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
-        Constant { const = `Bitvector bv2 } )
-      when Bitvec.is_zero bv2 ->
-        Some (ZeroEqual (fix a, bvconst (Bitvec.neg bv)))
-    | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
-        Constant { const = `Bitvector bv } )
-      when Bitvec.is_zero bv ->
-        Some (ZeroNegEqual (fix a, fix b))
-    | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
-        Constant { const = `Bitvector bv } )
-      when Bitvec.is_zero bv ->
-        Some (ZeroEqual (fix a, fix b))
-    | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
-        Some (ZeroIsZero (fix2 a))
+        c )
+      when is_zero c ->
+        Some (ZEqual (fix a, bvconst (Bitvec.neg bv)))
+    | ApplyIntrin { op = `BVADD; args = [ a; b ] }, c when is_zero c ->
+        Some (ZNegEqual (fix a, fix b))
+    | BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b }, c when is_zero c ->
+        Some (ZEqual (fix a, fix b))
+    | a, c when is_zero c -> Some (ZIsZero (fix2 a))
     | _ -> None
 
   let extract_semantics e =
     let e = Algsimp.normalise e in
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
+    let last_bit e bit =
+      Option.equal ( = ) (Types.bit_width @@ type_of e) (Some bit)
+    in
     match unfix3 e with
     | Constant { const = `Bitvector k }
       when Bitvec.equal k (Bitvec.zero ~size:1) ->
@@ -207,7 +199,6 @@ module FlagSemantics = struct
     | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
       ->
         extract_zero (unfix2 @@ fix arg1) (unfix2 @@ fix arg2)
-    (* OOPS need to check e1 = length of bitvectors *)
     | UnaryExpr
         {
           op = `Extract (e1, e2);
@@ -216,27 +207,18 @@ module FlagSemantics = struct
               { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] }
             as arg;
         }
-      when e1 = e2 + 1
-           && Option.equal ( = )
-                (Types.bit_width @@ type_of (fix2 arg))
-                (Some e1) ->
-        Some (NegSlt (fix a, bvconst (Bitvec.neg bv)))
+      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+        Some (NSlt (fix a, bvconst (Bitvec.neg bv)))
     | UnaryExpr
         {
           op = `Extract (e1, e2);
           arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b } as arg;
         }
-      when e1 = e2 + 1
-           && Option.equal ( = )
-                (Types.bit_width @@ type_of (fix2 arg))
-                (Some e1) ->
-        Some (NegSlt (fix a, fix b))
+      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+        Some (NSlt (fix a, fix b))
     | UnaryExpr { op = `Extract (e1, e2); arg }
-      when e1 = e2 + 1
-           && Option.equal ( = )
-                (Types.bit_width @@ type_of (fix2 arg))
-                (Some e1) ->
-        Some (NegIsNeg (fix2 arg))
+      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+        Some (NIsNeg (fix2 arg))
     | _ -> None
 end
 

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -25,205 +25,207 @@ module FlagSemantics = struct
         (** When left < right signed *)
     | IsNeg of Expr.BasilExpr.t  (** When expr is negative *)
   [@@deriving show { with_path = false }]
-end
 
-let extract_semantics e =
-  let e = Algsimp.normalise e in
-  let open Expr.AbstractExpr in
-  let open Expr.BasilExpr in
-  let equal e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
-  let sext_eq extension bv1 bv2 =
-    Bitvec.(equal (sign_extend ~extension bv1) bv2)
-  in
-  let zext_eq extension bv1 bv2 =
-    Bitvec.(equal (zero_extend ~extension bv1) bv2)
-  in
-  let is_one bv = Bitvec.(equal bv (one ~size:(size bv))) in
-  match unfix3 e with
-  | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.zero ~size:1)
-    ->
-      Some FlagSemantics.Never
-  | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.one ~size:1)
-    ->
-      Some FlagSemantics.Always
-  | UnaryExpr
-      {
-        op = `BVNOT;
-        arg =
-          UnaryExpr
-            { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
-      } -> (
-      match (unfix3 arg1, unfix3 arg2) with
-      | ( UnaryExpr
-            {
-              op = `SignExtend s1;
-              arg =
-                ApplyIntrin
-                  {
-                    op = `BVADD;
-                    args =
-                      [
-                        a;
-                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
-                      ];
-                  };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `SignExtend s2; arg = c };
-                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                ];
-            } )
-        when s1 = s2 && s1 > 0
-             && equal (fix a) (fix c)
-             && k2 = k1 + s1
-             && sext_eq s1 bv1 bv2 ->
-          Some (FlagSemantics.OverflowByConst (fix a, bv1))
-      | ( UnaryExpr
-            {
-              op = `SignExtend s1;
-              arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `SignExtend s2; arg = c };
-                  UnaryExpr { op = `SignExtend s3; arg = d };
-                ];
-            } )
-        when s1 = s2 && s2 = s3
-             && equal (fix a) (fix c)
-             && equal (fix b) (fix d) ->
-          Some (FlagSemantics.OverflowBySum (fix a, fix b))
-      | ( UnaryExpr
-            {
-              op = `SignExtend s1;
-              arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-            },
-          BinaryExpr
-            {
-              op = `BVSUB;
-              arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
-              arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
-            } )
-        when s1 = s2 && s2 = s3
-             && equal (fix a) (fix c)
-             && equal (fix b) (fix d) ->
-          Some (FlagSemantics.OverflowByDiff (fix a, fix b))
-      | ( UnaryExpr
-            {
-              op = `ZeroExtend s1;
-              arg =
-                ApplyIntrin
-                  {
-                    op = `BVADD;
-                    args =
-                      [
-                        a;
-                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
-                      ];
-                  };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `ZeroExtend s2; arg = c };
-                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                ];
-            } )
-        when s1 = s2 && s1 > 0
-             && equal (fix a) (fix c)
-             && k2 = k1 + s1
-             && zext_eq s1 bv1 bv2 ->
-          Some (FlagSemantics.CarryByConst (fix a, bv1))
-      | ( UnaryExpr
-            {
-              op = `ZeroExtend z1;
-              arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `ZeroExtend z2; arg = c };
-                  UnaryExpr { op = `ZeroExtend z3; arg = d };
-                ];
-            } )
-        when z1 = z2 && z2 = z3
-             && equal (fix a) (fix c)
-             && equal (fix b) (fix d) ->
-          Some (FlagSemantics.CarryBySum (fix a, fix b))
-      | ( UnaryExpr
-            {
-              op = `ZeroExtend z1;
-              arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `ZeroExtend z2; arg = c };
-                  UnaryExpr
+  let extract_semantics e =
+    let e = Algsimp.normalise e in
+    let open Expr.AbstractExpr in
+    let open Expr.BasilExpr in
+    let equal e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
+    let sext_eq extension bv1 bv2 =
+      Bitvec.(equal (sign_extend ~extension bv1) bv2)
+    in
+    let zext_eq extension bv1 bv2 =
+      Bitvec.(equal (zero_extend ~extension bv1) bv2)
+    in
+    let is_one bv = Bitvec.(equal bv (one ~size:(size bv))) in
+    match unfix3 e with
+    | Constant { const = `Bitvector k }
+      when Bitvec.equal k (Bitvec.zero ~size:1) ->
+        Some Never
+    | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.one ~size:1)
+      ->
+        Some Always
+    | UnaryExpr
+        {
+          op = `BVNOT;
+          arg =
+            UnaryExpr
+              { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
+        } -> (
+        match (unfix3 arg1, unfix3 arg2) with
+        | ( UnaryExpr
+              {
+                op = `SignExtend s1;
+                arg =
+                  ApplyIntrin
                     {
-                      op = `ZeroExtend z3;
-                      arg = UnaryExpr { op = `BVNOT; arg = d };
+                      op = `BVADD;
+                      args =
+                        [
+                          a;
+                          Constant
+                            { const = `Bitvector bv1; typ = Bitvector k1 };
+                        ];
                     };
-                  Constant { const = `Bitvector bv };
-                ];
-            } )
-        when z1 = z2 && z2 = z3
-             && equal (fix a) (fix c)
-             && equal (fix b) d
-             && is_one bv ->
-          Some (FlagSemantics.CarryByDiff (fix a, fix b))
-      | _ -> None)
-  | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
-    -> (
-      match (unfix2 @@ fix arg1, unfix2 @@ fix arg2) with
-      | ( ApplyIntrin
-            { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
-          Constant { const = `Bitvector bv2 } )
-        when Bitvec.is_zero bv2 ->
-          Some (FlagSemantics.Equal (fix a, bvconst (Bitvec.neg bv)))
-      | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
-          Constant { const = `Bitvector bv } )
-        when Bitvec.is_zero bv ->
-          Some (FlagSemantics.NegEqual (fix a, fix b))
-      | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
-          Constant { const = `Bitvector bv } )
-        when Bitvec.is_zero bv ->
-          Some (FlagSemantics.Equal (fix a, fix b))
-      | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
-          Some (FlagSemantics.IsZero (fix2 a))
-      | _ -> None)
-  | UnaryExpr
-      {
-        op = `Extract (e1, e2);
-        arg =
-          ApplyIntrin
-            { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] };
-      }
-    when e1 = e2 + 1 ->
-      Some (FlagSemantics.Slt (fix a, bvconst (Bitvec.neg bv)))
-  | UnaryExpr
-      {
-        op = `Extract (e1, e2);
-        arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-      }
-    when e1 = e2 + 1 ->
-      Some (FlagSemantics.Slt (fix a, fix b))
-  | UnaryExpr { op = `Extract (e1, e2); arg } when e1 = e2 + 1 ->
-      Some (FlagSemantics.IsNeg (fix2 arg))
-  | _ -> None
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `SignExtend s2; arg = c };
+                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                  ];
+              } )
+          when s1 = s2 && s1 > 0
+               && equal (fix a) (fix c)
+               && k2 = k1 + s1
+               && sext_eq s1 bv1 bv2 ->
+            Some (OverflowByConst (fix a, bv1))
+        | ( UnaryExpr
+              {
+                op = `SignExtend s1;
+                arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `SignExtend s2; arg = c };
+                    UnaryExpr { op = `SignExtend s3; arg = d };
+                  ];
+              } )
+          when s1 = s2 && s2 = s3
+               && equal (fix a) (fix c)
+               && equal (fix b) (fix d) ->
+            Some (OverflowBySum (fix a, fix b))
+        | ( UnaryExpr
+              {
+                op = `SignExtend s1;
+                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+              },
+            BinaryExpr
+              {
+                op = `BVSUB;
+                arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
+                arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
+              } )
+          when s1 = s2 && s2 = s3
+               && equal (fix a) (fix c)
+               && equal (fix b) (fix d) ->
+            Some (OverflowByDiff (fix a, fix b))
+        | ( UnaryExpr
+              {
+                op = `ZeroExtend s1;
+                arg =
+                  ApplyIntrin
+                    {
+                      op = `BVADD;
+                      args =
+                        [
+                          a;
+                          Constant
+                            { const = `Bitvector bv1; typ = Bitvector k1 };
+                        ];
+                    };
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `ZeroExtend s2; arg = c };
+                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                  ];
+              } )
+          when s1 = s2 && s1 > 0
+               && equal (fix a) (fix c)
+               && k2 = k1 + s1
+               && zext_eq s1 bv1 bv2 ->
+            Some (CarryByConst (fix a, bv1))
+        | ( UnaryExpr
+              {
+                op = `ZeroExtend z1;
+                arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `ZeroExtend z2; arg = c };
+                    UnaryExpr { op = `ZeroExtend z3; arg = d };
+                  ];
+              } )
+          when z1 = z2 && z2 = z3
+               && equal (fix a) (fix c)
+               && equal (fix b) (fix d) ->
+            Some (CarryBySum (fix a, fix b))
+        | ( UnaryExpr
+              {
+                op = `ZeroExtend z1;
+                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `ZeroExtend z2; arg = c };
+                    UnaryExpr
+                      {
+                        op = `ZeroExtend z3;
+                        arg = UnaryExpr { op = `BVNOT; arg = d };
+                      };
+                    Constant { const = `Bitvector bv };
+                  ];
+              } )
+          when z1 = z2 && z2 = z3
+               && equal (fix a) (fix c)
+               && equal (fix b) d
+               && is_one bv ->
+            Some (CarryByDiff (fix a, fix b))
+        | _ -> None)
+    | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
+      -> (
+        match (unfix2 @@ fix arg1, unfix2 @@ fix arg2) with
+        | ( ApplyIntrin
+              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
+            Constant { const = `Bitvector bv2 } )
+          when Bitvec.is_zero bv2 ->
+            Some (Equal (fix a, bvconst (Bitvec.neg bv)))
+        | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
+            Constant { const = `Bitvector bv } )
+          when Bitvec.is_zero bv ->
+            Some (NegEqual (fix a, fix b))
+        | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
+            Constant { const = `Bitvector bv } )
+          when Bitvec.is_zero bv ->
+            Some (Equal (fix a, fix b))
+        | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
+            Some (IsZero (fix2 a))
+        | _ -> None)
+    | UnaryExpr
+        {
+          op = `Extract (e1, e2);
+          arg =
+            ApplyIntrin
+              { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] };
+        }
+      when e1 = e2 + 1 ->
+        Some (Slt (fix a, bvconst (Bitvec.neg bv)))
+    | UnaryExpr
+        {
+          op = `Extract (e1, e2);
+          arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+        }
+      when e1 = e2 + 1 ->
+        Some (Slt (fix a, fix b))
+    | UnaryExpr { op = `Extract (e1, e2); arg } when e1 = e2 + 1 ->
+        Some (IsNeg (fix2 arg))
+    | _ -> None
+end
 
 (** Add flag semantic annotations as attributes for debugging *)
 let annotate_flag_assigns stmt =
@@ -233,7 +235,7 @@ let annotate_flag_assigns stmt =
       let annotations =
         List.filter_map
           (fun (v, e) ->
-            let o = extract_semantics e in
+            let o = FlagSemantics.extract_semantics e in
             if
               Option.is_none o
               && String.starts_with ~prefix:"$PSTATE_" (Var.name v)

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -20,7 +20,7 @@ module FlagSemantics = struct
     let open Types in
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
-    let equal e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
+    let equiv_exp e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
     let sext_eq extension bv1 bv2 =
       Bitvec.(equal (sign_extend ~extension bv1) bv2)
     in
@@ -48,7 +48,8 @@ module FlagSemantics = struct
                 Constant { const = `Bitvector bv2 };
               ];
           } )
-      when s1 = s2 && s1 > 0 && equal (fix a) (fix c) && sext_eq s1 bv1 bv2 ->
+      when s1 = s2 && s1 > 0 && equiv_exp (fix a) (fix c) && sext_eq s1 bv1 bv2
+      ->
         if Bitvec.is_negative bv1 then
           Some (O (Diff (fix a, bvconst (Bitvec.neg bv1))))
         else Some (O (Sum (fix a, bvconst bv1)))
@@ -67,8 +68,8 @@ module FlagSemantics = struct
               ];
           } )
       when s1 = s2 && s2 = s3 && s1 > 0
-           && equal (fix a) (fix c)
-           && equal (fix b) (fix d) ->
+           && equiv_exp (fix a) (fix c)
+           && equiv_exp (fix b) (fix d) ->
         Some (O (Sum (fix a, fix b)))
     | ( UnaryExpr
           {
@@ -82,8 +83,8 @@ module FlagSemantics = struct
             arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
           } )
       when s1 = s2 && s2 = s3 && s1 > 0
-           && equal (fix a) (fix c)
-           && equal (fix b) (fix d) ->
+           && equiv_exp (fix a) (fix c)
+           && equiv_exp (fix b) (fix d) ->
         Some (O (Diff (fix a, fix b)))
     | ( UnaryExpr
           {
@@ -104,7 +105,8 @@ module FlagSemantics = struct
                 Constant { const = `Bitvector bv2 };
               ];
           } )
-      when z1 = z2 && z1 > 0 && equal (fix a) (fix c) && zext_eq z1 bv1 bv2 ->
+      when z1 = z2 && z1 > 0 && equiv_exp (fix a) (fix c) && zext_eq z1 bv1 bv2
+      ->
         if Bitvec.is_negative bv1 then
           Some (C (Diff (fix a, bvconst (Bitvec.neg bv1))))
         else Some (O (Sum (fix a, bvconst bv1)))
@@ -123,8 +125,8 @@ module FlagSemantics = struct
               ];
           } )
       when z1 = z2 && z2 = z3 && z1 > 0
-           && equal (fix a) (fix c)
-           && equal (fix b) (fix d) ->
+           && equiv_exp (fix a) (fix c)
+           && equiv_exp (fix b) (fix d) ->
         Some (C (Sum (fix a, fix b)))
     | ( UnaryExpr
           {
@@ -146,8 +148,8 @@ module FlagSemantics = struct
               ];
           } )
       when z1 = z2 && z2 = z3 && z1 > 0
-           && equal (fix a) (fix c)
-           && equal (fix b) d
+           && equiv_exp (fix a) (fix c)
+           && equiv_exp (fix b) d
            && is_one bv ->
         Some (C (Diff (fix a, fix b)))
     | _ -> None
@@ -168,10 +170,6 @@ module FlagSemantics = struct
     let e = Algsimp.normalise e in
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
-    let is_msb e (top, bot) =
-      top = bot + 1
-      && Option.equal ( = ) (Types.bit_width @@ type_of e) (Some top)
-    in
     match unfix3 e with
     | Constant { const = `Bitvector k }
       when Bitvec.equal k (Bitvec.zero ~size:1) ->
@@ -196,7 +194,11 @@ module FlagSemantics = struct
         }
       when Bitvec.is_zero bv ->
         Some (Z (extract_expr (fix arg1)))
-    | UnaryExpr { op = `Extract ex; arg } when is_msb (fix2 arg) ex ->
+    | UnaryExpr { op = `Extract (e1, e2); arg }
+      when e1 = e2 + 1
+           && Option.equal ( = )
+                (Types.bit_width @@ type_of (fix2 arg))
+                (Some e1) ->
         Some (N (extract_expr (fix2 arg)))
     | _ -> None
 end

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -22,6 +22,10 @@ module FlagSemantics = struct
         (** Carry when subtracting first from second *)
     | CarryBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Carry when adding first and second *)
+    | NegEqual of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** When left == -right (or -left == right) *)
+    | Equal of Expr.BasilExpr.t * Expr.BasilExpr.t  (** When left == right *)
+    | IsZero of Expr.BasilExpr.t  (** When expr is zero *)
   [@@deriving show { with_path = false }]
 end
 
@@ -142,34 +146,6 @@ let extract_semantics e =
           Some (FlagSemantics.CarryByConst (fix a, bv1))
       | ( UnaryExpr
             {
-              op = `ZeroExtend s1;
-              arg =
-                ApplyIntrin
-                  {
-                    op = `BVADD;
-                    args =
-                      [
-                        a;
-                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
-                      ];
-                  };
-            },
-          ApplyIntrin
-            {
-              op = `BVADD;
-              args =
-                [
-                  UnaryExpr { op = `ZeroExtend s2; arg = c };
-                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                ];
-            } )
-        when s1 = s2 && s1 > 0
-             && equal (fix a) (fix c)
-             && k2 = k1 + s1
-             && zext_eq s1 bv1 bv2 ->
-          Some (FlagSemantics.CarryByConst (fix a, bv1))
-      | ( UnaryExpr
-            {
               op = `ZeroExtend z1;
               arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
             },
@@ -211,6 +187,25 @@ let extract_semantics e =
              && is_one bv ->
           Some (FlagSemantics.CarryByDiff (fix a, fix b))
       | _ -> None)
+  | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
+    -> (
+      match (unfix2 @@ fix arg1, unfix2 @@ fix arg2) with
+      | ( ApplyIntrin
+            { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
+          Constant { const = `Bitvector bv2 } )
+        when Bitvec.is_zero bv2 ->
+          Some (FlagSemantics.Equal (fix a, bvconst (Bitvec.neg bv)))
+      | ( ApplyIntrin { op = `BVADD; args = [ a; b ] },
+          Constant { const = `Bitvector bv } )
+        when Bitvec.is_zero bv ->
+          Some (FlagSemantics.NegEqual (fix a, fix b))
+      | ( BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b },
+          Constant { const = `Bitvector bv } )
+        when Bitvec.is_zero bv ->
+          Some (FlagSemantics.Equal (fix a, fix b))
+      | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
+          Some (FlagSemantics.IsZero (fix2 a))
+      | _ -> None)
   | _ -> None
 
 (** Add flag semantic annotations as attributes for debugging *)
@@ -222,7 +217,7 @@ let annotate_stmt stmt =
         List.filter_map
           (fun (v, e) ->
             let o = extract_semantics e in
-            if Option.is_none o && String.equal (Var.name v) "$PSTATE_C" then
+            if Option.is_none o && String.equal (Var.name v) "$PSTATE_Z" then
               print_endline (Expr.BasilExpr.to_string (Algsimp.normalise e));
             o |> Option.map (fun s -> (v, s)))
           al

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -277,61 +277,28 @@ var $PSTATE_V:bv1;
 proc @main() -> ()
 [
   block %main [
-     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-        bvadd(extract(32,0, $R0), 0x1:bv32)),
-        bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64))));
-     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-        bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
-        bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
-         0x1:bv64))));
-     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-        bvadd(bvadd(extract(32,0, $R0),
-          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
-        bvadd(bvadd(sign_extend(32, extract(32,0, $R0)),
-          sign_extend(32,
-          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
-     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-        bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))),
-        bvadd(sign_extend(32, local_31:bv32),
-         sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64), 0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), sign_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))), bvadd(sign_extend(32, local_31:bv32), sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))))));
 
-     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-        bvadd(extract(32,0, $R0), 0x1:bv32)),
-        bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64))));
-     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-        bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
-        bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
-         0x1:bv64))));
-     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-        bvadd(bvadd(extract(32,0, $R0),
-          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
-        bvadd(bvadd(zero_extend(32, extract(32,0, $R0)),
-          zero_extend(32,
-          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
-     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-        bvadd($H2:bv32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))),
-        bvadd(zero_extend(32, $H2:bv32),
-         zero_extend(32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64), 0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), zero_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd($H2:bv32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))), bvadd(zero_extend(32, $H2:bv32), zero_extend(32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))))));
 
-     $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2:bv32,
-        bvshl($H3:bv32, zero_extend(20, 0x0:bv12))), 0x0:bv32));
+     $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2:bv32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12))), 0x0:bv32));
      $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32));
-     $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
-         bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
-       0x0:bv32));
+     $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32), 0x0:bv32));
 
      $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32));
-     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-       bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
-     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-       0xffffffff:bv32), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32));
 
      // should not be annotated!
      $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
-     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
-       bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
-     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
-       0xffffffff:bv32), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32));
 
      $PSTATE_V:bv1 := 0x0:bv1;
      $PSTATE_C:bv1 := 0x0:bv1;
@@ -350,7 +317,7 @@ prog entry @main;
     lst.prog |> Program.map_procedures (fun _ -> annotate_flag_assign_stmts)
   in
   print_endline
-  @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
+  @@ Containers_pp.Pretty.to_string ~width:800 (Lang.Program.prog_pretty prog);
   [%expect
     {|
     var $R0:bv64;
@@ -363,61 +330,27 @@ prog entry @main;
     var $PSTATE_V:bv1;
     proc @main()  -> () {  }
       modifies $PSTATE_C:bv1, $PSTATE_N:bv1, $PSTATE_V:bv1, $PSTATE_Z:bv1
-      captures $H2:bv64, $H3:bv64, $PSTATE_C:bv1, $PSTATE_N:bv1, $PSTATE_V:bv1,
-        $PSTATE_Z:bv1, $R0:bv64, $R1:bv64
+      captures $H2:bv64, $H3:bv64, $PSTATE_C:bv1, $PSTATE_N:bv1, $PSTATE_V:bv1, $PSTATE_Z:bv1, $R0:bv64, $R1:bv64
 
     [
        block %main [
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-            bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0x1:bv32))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-            bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
-            bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-            bvadd(bvadd(extract(32,0, $R0),
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
-            bvadd(bvadd(sign_extend(32, extract(32,0, $R0)),
-              sign_extend(32,
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
-            bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))),
-            bvadd(sign_extend(32, local_31:bv32),
-             sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OBySum (local_31:bv32, local_32:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-            bvadd(extract(32,0, $R0), 0x1:bv32)),
-            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0x1:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-            bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
-            bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
-             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-            bvadd(bvadd(extract(32,0, $R0),
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
-            bvadd(bvadd(zero_extend(32, extract(32,0, $R0)),
-              zero_extend(32,
-              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
-            bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))),
-            bvadd(zero_extend(32, $H2),
-             zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CBySum ($H2, $H3))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2,
-            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZNegEqual ($H2, $H3))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0x1:bv32))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), sign_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32, bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))), bvadd(sign_extend(32, local_31:bv32), sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OBySum (local_31:bv32, local_32:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(extract(32,0, $R0), 0x1:bv32)), bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0x1:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CBySum (extract(32,0, $R0), 0xfffffffe:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), zero_extend(32, bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32, bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))), bvadd(zero_extend(32, $H2), zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CBySum ($H2, $H3))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZNegEqual ($H2, $H3))" };
          $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), 0xffffffff:bv32))" };
-         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
-             bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
-           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(ZEqual (extract(32,0, $R0), extract(32,0, $R1)))" };
          $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), 0xffffffff:bv32))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
-         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
-           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NIsNeg extract(32,0, $R0))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NSlt (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(NIsNeg extract(32,0, $R0))" };
          $PSTATE_N:bv1 := extract(31,30, bvadd(extract(32,0, $R0), 0x1:bv32));
-         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
-           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
-         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0),
-           0xffffffff:bv32), 0x1:bv32));
+         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+         $PSTATE_N:bv1 := extract(31,30, bvadd(bvadd(extract(32,0, $R0), 0xffffffff:bv32), 0x1:bv32));
          $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
          $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
          $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -178,8 +178,9 @@ module FlagSemantics = struct
     let e = Algsimp.normalise e in
     let open Expr.AbstractExpr in
     let open Expr.BasilExpr in
-    let last_bit e bit =
-      Option.equal ( = ) (Types.bit_width @@ type_of e) (Some bit)
+    let is_msb e (top, bot) =
+      top = bot + 1
+      && Option.equal ( = ) (Types.bit_width @@ type_of e) (Some top)
     in
     match unfix3 e with
     | Constant { const = `Bitvector k }
@@ -201,23 +202,22 @@ module FlagSemantics = struct
         extract_zero (fix arg1) (fix arg2)
     | UnaryExpr
         {
-          op = `Extract (e1, e2);
+          op = `Extract ex;
           arg =
             ApplyIntrin
               { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] }
             as arg;
         }
-      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+      when is_msb (fix2 arg) ex ->
         Some (NSlt (fix a, bvconst (Bitvec.neg bv)))
     | UnaryExpr
         {
-          op = `Extract (e1, e2);
+          op = `Extract ex;
           arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b } as arg;
         }
-      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+      when is_msb (fix2 arg) ex ->
         Some (NSlt (fix a, fix b))
-    | UnaryExpr { op = `Extract (e1, e2); arg }
-      when e1 = e2 + 1 && last_bit (fix2 arg) e1 ->
+    | UnaryExpr { op = `Extract ex; arg } when is_msb (fix2 arg) ex ->
         Some (NIsNeg (fix2 arg))
     | _ -> None
 end

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -1,125 +1,113 @@
 open Bincaml_util.Common
 open Lang
 
-(*
+(* instead of rewriting shapes, we should perform an analysis that assigns to each flag+codepoint an abstract value corresponding to its semantic meaning! Then we can rewrite assumes with the semantic meaning!
+   For soundness, delete terms of the analysis value map whenever a variable present in the map is assigned to.
+   This should not lose any precision since branch conditions should only occur directly after flag assignment!
+ *)
 
-eq(sext(32, bvadd(a:bv32, b:bv32)), bvadd(sext(32, a:bv32), sext(32, b:bv64)))
-is an overflow check
-can also be 64 and 128 bit...
+module FlagSemantics = struct
+  type t =
+    | Never
+    | Always
+    | OverflowByConst of Expr.BasilExpr.t * Bitvec.t
+        (** Overflow when adding expr and const *)
+    | OverflowByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** Overflow when subtracting first from second *)
+  [@@deriving show]
+end
 
-$PSTATE_V:bv1 :=
-bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R26), bvnot(bvshl(extract(32,0, $R27), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R26)), sign_extend(32, bvnot(bvshl(extract(32,0, $R27), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
-
-->
-
-$PSTATE_V:bv1 :=
-bvnot(booltobv1(eq(sign_extend(32, bvsub(extract(32,0, $R26), extract(32,0, $R27))), bvsub(sign_extend(32, extract(32,0, $R26)), sign_extend(32, extract(32,0, $R27))))));
-also an overflow check!
-*)
-
-(** Rewrite common shapes of expressions *)
-let specific_rewrites e =
+let extract_semantics e =
+  let e = Algsimp.normalise e in
   let open Expr.AbstractExpr in
   let open Expr.BasilExpr in
   let sext_eq extension bv1 bv2 =
     Bitvec.equal (Bitvec.sign_extend ~extension bv1) bv2
   in
-  (* Get size of bv expr if it is one *)
-  let size_of e =
-    match type_of e with Types.Bitvector k -> Some k | _ -> None
-  in
-  let rw_fun (e : O.t abstract_expr) =
-    match e with
-    | BinaryExpr { op = `EQ; arg1; arg2 } -> (
-        match (unfix3 arg1, unfix3 arg2) with
-        | ( UnaryExpr
-              {
-                op = `SignExtend s1;
-                arg =
-                  ApplyIntrin
-                    {
-                      op = `BVADD;
-                      args =
-                        [
-                          a;
-                          Constant
-                            { const = `Bitvector bv1; typ = Bitvector k1 };
-                        ];
-                    };
-              },
-            ApplyIntrin
-              {
-                op = `BVADD;
-                args =
-                  [
-                    UnaryExpr { op = `SignExtend s2; arg = c };
-                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
-                  ];
-              } )
-          when s1 = s2 && s1 > 0
-               && equal (fix a) (fix c)
-               && k2 = k1 + s1
-               && sext_eq s1 bv1 bv2 ->
-            (* Overflow check when adding by a constant bv1 working with k1 bits *)
-            if Bitvec.sgt bv1 (Bitvec.zero ~size:k1) then
-              replace [%here]
-                (binexp ~op:`BVSLE (fix a)
-                   (bvconst (Bitvec.sub (Bitvec.max_value_signed k1) bv1)))
-            else if Bitvec.slt bv1 (Bitvec.zero ~size:k1) then
-              replace [%here]
-                (binexp ~op:`BVSLE
-                   (bvconst (Bitvec.sub (Bitvec.min_value_signed k1) bv1))
-                   (fix a))
-            else Keep
-        | ( UnaryExpr
-              {
-                op = `SignExtend s1;
-                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
-              },
-            BinaryExpr
-              {
-                op = `BVSUB;
-                arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
-                arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
-              } )
-          when s1 = s2 && s2 = s3
-               && equal (fix a) (fix c)
-               && equal (fix b) (fix d) -> (
-            (* Overflow check when subtracting two variables *)
-            let a = fix a in
-            let b = fix b in
-            match size_of a with
-            | Some size ->
-                let z = bvconst (Bitvec.zero ~size) in
-                let max = bvconst (Bitvec.max_value_signed size) in
-                let min = bvconst (Bitvec.min_value_signed size) in
-                replace [%here]
-                  (applyintrin ~op:`OR
-                     [
-                       applyintrin ~op:`AND
-                         [
-                           binexp ~op:`BVSLE z b;
-                           binexp ~op:`BVSLE a (binexp ~op:`BVSUB max b);
-                         ];
-                       applyintrin ~op:`AND
-                         [
-                           binexp ~op:`BVSLT b z;
-                           binexp ~op:`BVSLE (binexp ~op:`BVSUB min b) a;
-                         ];
-                     ])
-            | _ -> Keep)
-        | _ -> Keep)
-    | _ -> Keep
-  in
-  rewrite ~rw_fun e
+  match unfix3 e with
+  | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.zero ~size:1)
+    ->
+      Some FlagSemantics.Never
+  | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.one ~size:1)
+    ->
+      Some FlagSemantics.Always
+  | UnaryExpr
+      {
+        op = `BVNOT;
+        arg =
+          UnaryExpr
+            { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
+      } -> (
+      match (unfix3 arg1, unfix3 arg2) with
+      | ( UnaryExpr
+            {
+              op = `SignExtend s1;
+              arg =
+                ApplyIntrin
+                  {
+                    op = `BVADD;
+                    args =
+                      [
+                        a;
+                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
+                      ];
+                  };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `SignExtend s2; arg = c };
+                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                ];
+            } )
+        when s1 = s2 && s1 > 0
+             && equal (fix a) (fix c)
+             && k2 = k1 + s1
+             && sext_eq s1 bv1 bv2 ->
+          Some (FlagSemantics.OverflowByConst (fix a, bv1))
+      | ( UnaryExpr
+            {
+              op = `SignExtend s1;
+              arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+            },
+          BinaryExpr
+            {
+              op = `BVSUB;
+              arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
+              arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
+            } )
+        when s1 = s2 && s2 = s3
+             && equal (fix a) (fix c)
+             && equal (fix b) (fix d) ->
+          Some (FlagSemantics.OverflowByDiff (fix a, fix b))
+      | _ -> None)
+  | _ -> None
 
-let rewrite_expr e =
-  e |> Algsimp.normalise |> specific_rewrites |> Algsimp.normalise
+(** Add flag semantic annotations as attributes for debugging *)
+let annotate_stmt stmt =
+  let open Stmt in
+  match stmt with
+  | Instr_Assign { attrib; al } ->
+      let annotations =
+        List.filter_map
+          (fun (v, e) -> extract_semantics e |> Option.map (fun s -> (v, s)))
+          al
+      in
+      let attrib =
+        List.fold_left
+          (fun attrib (v, s) ->
+            StringMap.add
+              (".flag_semantics_" ^ Var.name v)
+              (`String (FlagSemantics.show s))
+              attrib)
+          attrib annotations
+      in
+      Instr_Assign { attrib; al }
+  | _ -> stmt
 
 let transform (p : Program.proc) =
   Procedure.map_blocks_nondet
-    (fun (bid, block) ->
-      Block.map ~phi:id
-        (Stmt.map ~f_lvar:id ~f_rvar:id ~f_expr:rewrite_expr)
-        block)
+    (fun (bid, block) -> Block.map ~phi:id annotate_stmt block)
     p

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -34,7 +34,7 @@ module FlagSemantics = struct
       Bitvec.(equal (zero_extend ~extension bv1) bv2)
     in
     let is_one bv = Bitvec.(equal bv (one ~size:(size bv))) in
-    match (arg1, arg2) with
+    match (unfix3 arg1, unfix3 arg2) with
     | ( UnaryExpr
           {
             op = `SignExtend s1;
@@ -161,7 +161,7 @@ module FlagSemantics = struct
       | Constant { const = `Bitvector bv } -> Bitvec.is_zero bv
       | _ -> false
     in
-    match (arg1, arg2) with
+    match (unfix2 arg1, unfix2 arg2) with
     | ( ApplyIntrin
           { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] },
         c )
@@ -195,10 +195,10 @@ module FlagSemantics = struct
             UnaryExpr
               { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } };
         } ->
-        extract_overflow_cary (unfix3 arg1) (unfix3 arg2)
+        extract_overflow_cary arg1 arg2
     | UnaryExpr { op = `BOOLTOBV1; arg = BinaryExpr { op = `EQ; arg1; arg2 } }
       ->
-        extract_zero (unfix2 @@ fix arg1) (unfix2 @@ fix arg2)
+        extract_zero (fix arg1) (fix arg2)
     | UnaryExpr
         {
           op = `Extract (e1, e2);

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -26,6 +26,9 @@ module FlagSemantics = struct
         (** When left == -right (or -left == right) *)
     | Equal of Expr.BasilExpr.t * Expr.BasilExpr.t  (** When left == right *)
     | IsZero of Expr.BasilExpr.t  (** When expr is zero *)
+    | Slt of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** When left < right signed *)
+    | IsNeg of Expr.BasilExpr.t  (** When expr is negative *)
   [@@deriving show { with_path = false }]
 end
 
@@ -206,20 +209,34 @@ let extract_semantics e =
       | a, Constant { const = `Bitvector bv } when Bitvec.is_zero bv ->
           Some (FlagSemantics.IsZero (fix2 a))
       | _ -> None)
+  | UnaryExpr
+      {
+        op = `Extract (e1, e2);
+        arg =
+          ApplyIntrin
+            { op = `BVADD; args = [ a; Constant { const = `Bitvector bv } ] };
+      }
+    when e1 = e2 + 1 ->
+      Some (FlagSemantics.Slt (fix a, bvconst (Bitvec.neg bv)))
+  | UnaryExpr
+      {
+        op = `Extract (e1, e2);
+        arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+      }
+    when e1 = e2 + 1 ->
+      Some (FlagSemantics.Slt (fix a, fix b))
+  | UnaryExpr { op = `Extract (e1, e2); arg } when e1 = e2 + 1 ->
+      Some (FlagSemantics.IsNeg (fix2 arg))
   | _ -> None
 
 (** Add flag semantic annotations as attributes for debugging *)
-let annotate_stmt stmt =
+let annotate_flag_assigns stmt =
   let open Stmt in
   match stmt with
   | Instr_Assign { attrib; al } ->
       let annotations =
         List.filter_map
-          (fun (v, e) ->
-            let o = extract_semantics e in
-            if Option.is_none o && String.equal (Var.name v) "$PSTATE_Z" then
-              print_endline (Expr.BasilExpr.to_string (Algsimp.normalise e));
-            o |> Option.map (fun s -> (v, s)))
+          (fun (v, e) -> extract_semantics e |> Option.map (fun s -> (v, s)))
           al
       in
       let attrib =
@@ -236,5 +253,5 @@ let annotate_stmt stmt =
 
 let transform (p : Program.proc) =
   Procedure.map_blocks_nondet
-    (fun (bid, block) -> Block.map ~phi:id annotate_stmt block)
+    (fun (bid, block) -> Block.map ~phi:id annotate_flag_assigns block)
     p

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -36,6 +36,7 @@ let extract_semantics e =
   let e = Algsimp.normalise e in
   let open Expr.AbstractExpr in
   let open Expr.BasilExpr in
+  let equal e1 e2 = equal (drop_attrib e1) (drop_attrib e2) in
   let sext_eq extension bv1 bv2 =
     Bitvec.(equal (sign_extend ~extension bv1) bv2)
   in
@@ -243,7 +244,7 @@ let annotate_flag_assigns stmt =
               && String.starts_with ~prefix:"$PSTATE_" (Var.name v)
             then
               Logs.debug (fun m ->
-                  m "%s had no assiged semantic meaning for expr %s"
+                  m "%s had no assigned semantic meaning for expr %s"
                     (Var.name v)
                     (Expr.BasilExpr.to_string (Algsimp.normalise e)));
             o |> Option.map (fun s -> (v, s)))
@@ -261,7 +262,165 @@ let annotate_flag_assigns stmt =
       Instr_Assign { attrib; al }
   | _ -> stmt
 
-let transform (p : Program.proc) =
+let annotate_flag_assign_stmts (p : Program.proc) =
   Procedure.map_blocks_nondet
     (fun (bid, block) -> Block.map ~phi:id annotate_flag_assigns block)
     p
+
+let transform = annotate_flag_assign_stmts
+
+let%expect_test "flag_types" =
+  let lst =
+    Loader.Loadir.ast_of_string
+      {|
+var $R0:bv64;
+var $R1:bv64;
+var $H2:bv64;
+var $H3:bv64;
+var $PSTATE_N:bv1;
+var $PSTATE_Z:bv1;
+var $PSTATE_C:bv1;
+var $PSTATE_V:bv1;
+
+proc @main() -> ()
+[
+  block %main [
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+        bvadd(extract(32,0, $R0), 0x1:bv32)),
+        bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+        bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
+        bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
+         0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+        bvadd(bvadd(extract(32,0, $R0),
+          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
+        bvadd(bvadd(sign_extend(32, extract(32,0, $R0)),
+          sign_extend(32,
+          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
+     $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+        bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))),
+        bvadd(sign_extend(32, local_31:bv32),
+         sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))))));
+
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+        bvadd(extract(32,0, $R0), 0x1:bv32)),
+        bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+        bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
+        bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
+         0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+        bvadd(bvadd(extract(32,0, $R0),
+          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
+        bvadd(bvadd(zero_extend(32, extract(32,0, $R0)),
+          zero_extend(32,
+          bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
+     $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+        bvadd($H2:bv32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))),
+        bvadd(zero_extend(32, $H2:bv32),
+         zero_extend(32, bvshl($H3:bv32, zero_extend(20, 0x0:bv12)))))));
+
+     $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2:bv32,
+        bvshl($H3:bv32, zero_extend(20, 0x0:bv12))), 0x0:bv32));
+     $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32));
+     $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
+         bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
+       0x0:bv32));
+
+     $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
+       bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32));
+     $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
+       0xffffffff:bv32), 0x1:bv32));
+
+     $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
+     $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
+     $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };
+     $PSTATE_N:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_N = "Never" };
+
+    goto (%ret);
+  ];
+  block %ret [ return; ]
+];
+
+prog entry @main;
+    |}
+  in
+  let prog =
+    lst.prog |> Program.map_procedures (fun _ -> annotate_flag_assign_stmts)
+  in
+  print_endline
+  @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
+  [%expect
+    {|
+    var $R0:bv64;
+    var $R1:bv64;
+    var $H2:bv64;
+    var $H3:bv64;
+    var $PSTATE_N:bv1;
+    var $PSTATE_Z:bv1;
+    var $PSTATE_C:bv1;
+    var $PSTATE_V:bv1;
+    proc @main()  -> () {  }
+      modifies $PSTATE_C:bv1, $PSTATE_N:bv1, $PSTATE_V:bv1, $PSTATE_Z:bv1
+      captures $H2:bv64, $H3:bv64, $PSTATE_C:bv1, $PSTATE_N:bv1, $PSTATE_V:bv1,
+        $PSTATE_Z:bv1, $R0:bv64, $R1:bv64
+
+    [
+       block %main [
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+            bvadd(extract(32,0, $R0), 0x1:bv32)),
+            bvadd(sign_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByConst (extract(32,0, $R0), 0x1:bv32))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+            bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
+            bvadd(bvadd(sign_extend(32, extract(32,0, $R0)), 0xfffffffffffffffd:bv64),
+             0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByConst (extract(32,0, $R0), 0xfffffffe:bv32))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+            bvadd(bvadd(extract(32,0, $R0),
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
+            bvadd(bvadd(sign_extend(32, extract(32,0, $R0)),
+              sign_extend(32,
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_V = "(OverflowByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_V:bv1 := bvnot(booltobv1(eq(sign_extend(32,
+            bvadd(local_31:bv32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12)))),
+            bvadd(sign_extend(32, local_31:bv32),
+             sign_extend(32, bvshl(local_32:bv32, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_V = "(OverflowBySum (local_31:bv32, local_32:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+            bvadd(extract(32,0, $R0), 0x1:bv32)),
+            bvadd(zero_extend(32, extract(32,0, $R0)), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByConst (extract(32,0, $R0), 0x1:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+            bvadd(bvadd(extract(32,0, $R0), 0xfffffffd:bv32), 0x1:bv32)),
+            bvadd(bvadd(zero_extend(32, extract(32,0, $R0)), 0xfffffffd:bv64),
+             0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByConst (extract(32,0, $R0), 0xfffffffe:bv32))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+            bvadd(bvadd(extract(32,0, $R0),
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)),
+            bvadd(bvadd(zero_extend(32, extract(32,0, $R0)),
+              zero_extend(32,
+              bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12))))), 0x1:bv64)))) { .flag_semantics_$PSTATE_C = "(CarryByDiff (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_C:bv1 := bvnot(booltobv1(eq(zero_extend(32,
+            bvadd($H2, bvshl($H3, zero_extend(20, 0x0:bv12)))),
+            bvadd(zero_extend(32, $H2),
+             zero_extend(32, bvshl($H3, zero_extend(20, 0x0:bv12))))))) { .flag_semantics_$PSTATE_C = "(CarryBySum ($H2, $H3))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd($H2,
+            bvshl($H3, zero_extend(20, 0x0:bv12))), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(NegEqual ($H2, $H3))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(extract(32,0, $R0), 0x1:bv32), 0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Equal (extract(32,0, $R0), 0xffffffff:bv32))" };
+         $PSTATE_Z:bv1 := booltobv1(eq(bvadd(bvadd(extract(32,0, $R0),
+             bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32),
+           0x0:bv32)) { .flag_semantics_$PSTATE_Z = "(Equal (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(extract(32,0, $R0), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(Slt (extract(32,0, $R0), 0xffffffff:bv32))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
+           bvnot(bvshl(extract(32,0, $R1), zero_extend(20, 0x0:bv12)))), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(Slt (extract(32,0, $R0), extract(32,0, $R1)))" };
+         $PSTATE_N:bv1 := extract(32,31, bvadd(bvadd(extract(32,0, $R0),
+           0xffffffff:bv32), 0x1:bv32)) { .flag_semantics_$PSTATE_N = "(IsNeg extract(32,0, $R0))" };
+         $PSTATE_V:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_V = "Never" };
+         $PSTATE_C:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_C = "Never" };
+         $PSTATE_Z:bv1 := 0x1:bv1 { .flag_semantics_$PSTATE_Z = "Always" };
+         $PSTATE_N:bv1 := 0x0:bv1 { .flag_semantics_$PSTATE_N = "Never" };
+         goto (%ret);
+       ];
+       block %ret [ return; ]
+    ];
+    prog entry @main;
+    |}]

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -14,7 +14,15 @@ module FlagSemantics = struct
         (** Overflow when adding expr and const *)
     | OverflowByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
         (** Overflow when subtracting first from second *)
-  [@@deriving show]
+    | OverflowBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** Overflow when adding first and second *)
+    | CarryByConst of Expr.BasilExpr.t * Bitvec.t
+        (** Carry when adding expr and const *)
+    | CarryByDiff of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** Carry when subtracting first from second *)
+    | CarryBySum of Expr.BasilExpr.t * Expr.BasilExpr.t
+        (** Carry when adding first and second *)
+  [@@deriving show { with_path = false }]
 end
 
 let extract_semantics e =
@@ -22,8 +30,12 @@ let extract_semantics e =
   let open Expr.AbstractExpr in
   let open Expr.BasilExpr in
   let sext_eq extension bv1 bv2 =
-    Bitvec.equal (Bitvec.sign_extend ~extension bv1) bv2
+    Bitvec.(equal (sign_extend ~extension bv1) bv2)
   in
+  let zext_eq extension bv1 bv2 =
+    Bitvec.(equal (zero_extend ~extension bv1) bv2)
+  in
+  let is_one bv = Bitvec.(equal bv (one ~size:(size bv))) in
   match unfix3 e with
   | Constant { const = `Bitvector k } when Bitvec.equal k (Bitvec.zero ~size:1)
     ->
@@ -70,6 +82,24 @@ let extract_semantics e =
       | ( UnaryExpr
             {
               op = `SignExtend s1;
+              arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `SignExtend s2; arg = c };
+                  UnaryExpr { op = `SignExtend s3; arg = d };
+                ];
+            } )
+        when s1 = s2 && s2 = s3
+             && equal (fix a) (fix c)
+             && equal (fix b) (fix d) ->
+          Some (FlagSemantics.OverflowBySum (fix a, fix b))
+      | ( UnaryExpr
+            {
+              op = `SignExtend s1;
               arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
             },
           BinaryExpr
@@ -82,6 +112,104 @@ let extract_semantics e =
              && equal (fix a) (fix c)
              && equal (fix b) (fix d) ->
           Some (FlagSemantics.OverflowByDiff (fix a, fix b))
+      | ( UnaryExpr
+            {
+              op = `ZeroExtend s1;
+              arg =
+                ApplyIntrin
+                  {
+                    op = `BVADD;
+                    args =
+                      [
+                        a;
+                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
+                      ];
+                  };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `ZeroExtend s2; arg = c };
+                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                ];
+            } )
+        when s1 = s2 && s1 > 0
+             && equal (fix a) (fix c)
+             && k2 = k1 + s1
+             && zext_eq s1 bv1 bv2 ->
+          Some (FlagSemantics.CarryByConst (fix a, bv1))
+      | ( UnaryExpr
+            {
+              op = `ZeroExtend s1;
+              arg =
+                ApplyIntrin
+                  {
+                    op = `BVADD;
+                    args =
+                      [
+                        a;
+                        Constant { const = `Bitvector bv1; typ = Bitvector k1 };
+                      ];
+                  };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `ZeroExtend s2; arg = c };
+                  Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                ];
+            } )
+        when s1 = s2 && s1 > 0
+             && equal (fix a) (fix c)
+             && k2 = k1 + s1
+             && zext_eq s1 bv1 bv2 ->
+          Some (FlagSemantics.CarryByConst (fix a, bv1))
+      | ( UnaryExpr
+            {
+              op = `ZeroExtend z1;
+              arg = ApplyIntrin { op = `BVADD; args = [ a; b ] };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `ZeroExtend z2; arg = c };
+                  UnaryExpr { op = `ZeroExtend z3; arg = d };
+                ];
+            } )
+        when z1 = z2 && z2 = z3
+             && equal (fix a) (fix c)
+             && equal (fix b) (fix d) ->
+          Some (FlagSemantics.CarryBySum (fix a, fix b))
+      | ( UnaryExpr
+            {
+              op = `ZeroExtend z1;
+              arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+            },
+          ApplyIntrin
+            {
+              op = `BVADD;
+              args =
+                [
+                  UnaryExpr { op = `ZeroExtend z2; arg = c };
+                  UnaryExpr
+                    {
+                      op = `ZeroExtend z3;
+                      arg = UnaryExpr { op = `BVNOT; arg = d };
+                    };
+                  Constant { const = `Bitvector bv };
+                ];
+            } )
+        when z1 = z2 && z2 = z3
+             && equal (fix a) (fix c)
+             && equal (fix b) d
+             && is_one bv ->
+          Some (FlagSemantics.CarryByDiff (fix a, fix b))
       | _ -> None)
   | _ -> None
 
@@ -92,7 +220,11 @@ let annotate_stmt stmt =
   | Instr_Assign { attrib; al } ->
       let annotations =
         List.filter_map
-          (fun (v, e) -> extract_semantics e |> Option.map (fun s -> (v, s)))
+          (fun (v, e) ->
+            let o = extract_semantics e in
+            if Option.is_none o && String.equal (Var.name v) "$PSTATE_C" then
+              print_endline (Expr.BasilExpr.to_string (Algsimp.normalise e));
+            o |> Option.map (fun s -> (v, s)))
           al
       in
       let attrib =

--- a/lib/transforms/branch_conditions.ml
+++ b/lib/transforms/branch_conditions.ml
@@ -1,0 +1,125 @@
+open Bincaml_util.Common
+open Lang
+
+(*
+
+eq(sext(32, bvadd(a:bv32, b:bv32)), bvadd(sext(32, a:bv32), sext(32, b:bv64)))
+is an overflow check
+can also be 64 and 128 bit...
+
+$PSTATE_V:bv1 :=
+bvnot(booltobv1(eq(sign_extend(32, bvadd(bvadd(extract(32,0, $R26), bvnot(bvshl(extract(32,0, $R27), zero_extend(20, 0x0:bv12)))), 0x1:bv32)), bvadd(bvadd(sign_extend(32, extract(32,0, $R26)), sign_extend(32, bvnot(bvshl(extract(32,0, $R27), zero_extend(20, 0x0:bv12))))), 0x1:bv64))));
+
+->
+
+$PSTATE_V:bv1 :=
+bvnot(booltobv1(eq(sign_extend(32, bvsub(extract(32,0, $R26), extract(32,0, $R27))), bvsub(sign_extend(32, extract(32,0, $R26)), sign_extend(32, extract(32,0, $R27))))));
+also an overflow check!
+*)
+
+(** Rewrite common shapes of expressions *)
+let specific_rewrites e =
+  let open Expr.AbstractExpr in
+  let open Expr.BasilExpr in
+  let sext_eq extension bv1 bv2 =
+    Bitvec.equal (Bitvec.sign_extend ~extension bv1) bv2
+  in
+  (* Get size of bv expr if it is one *)
+  let size_of e =
+    match type_of e with Types.Bitvector k -> Some k | _ -> None
+  in
+  let rw_fun (e : O.t abstract_expr) =
+    match e with
+    | BinaryExpr { op = `EQ; arg1; arg2 } -> (
+        match (unfix3 arg1, unfix3 arg2) with
+        | ( UnaryExpr
+              {
+                op = `SignExtend s1;
+                arg =
+                  ApplyIntrin
+                    {
+                      op = `BVADD;
+                      args =
+                        [
+                          a;
+                          Constant
+                            { const = `Bitvector bv1; typ = Bitvector k1 };
+                        ];
+                    };
+              },
+            ApplyIntrin
+              {
+                op = `BVADD;
+                args =
+                  [
+                    UnaryExpr { op = `SignExtend s2; arg = c };
+                    Constant { const = `Bitvector bv2; typ = Bitvector k2 };
+                  ];
+              } )
+          when s1 = s2 && s1 > 0
+               && equal (fix a) (fix c)
+               && k2 = k1 + s1
+               && sext_eq s1 bv1 bv2 ->
+            (* Overflow check when adding by a constant bv1 working with k1 bits *)
+            if Bitvec.sgt bv1 (Bitvec.zero ~size:k1) then
+              replace [%here]
+                (binexp ~op:`BVSLE (fix a)
+                   (bvconst (Bitvec.sub (Bitvec.max_value_signed k1) bv1)))
+            else if Bitvec.slt bv1 (Bitvec.zero ~size:k1) then
+              replace [%here]
+                (binexp ~op:`BVSLE
+                   (bvconst (Bitvec.sub (Bitvec.min_value_signed k1) bv1))
+                   (fix a))
+            else Keep
+        | ( UnaryExpr
+              {
+                op = `SignExtend s1;
+                arg = BinaryExpr { op = `BVSUB; arg1 = a; arg2 = b };
+              },
+            BinaryExpr
+              {
+                op = `BVSUB;
+                arg1 = UnaryExpr { op = `SignExtend s2; arg = c };
+                arg2 = UnaryExpr { op = `SignExtend s3; arg = d };
+              } )
+          when s1 = s2 && s2 = s3
+               && equal (fix a) (fix c)
+               && equal (fix b) (fix d) -> (
+            (* Overflow check when subtracting two variables *)
+            let a = fix a in
+            let b = fix b in
+            match size_of a with
+            | Some size ->
+                let z = bvconst (Bitvec.zero ~size) in
+                let max = bvconst (Bitvec.max_value_signed size) in
+                let min = bvconst (Bitvec.min_value_signed size) in
+                replace [%here]
+                  (applyintrin ~op:`OR
+                     [
+                       applyintrin ~op:`AND
+                         [
+                           binexp ~op:`BVSLE z b;
+                           binexp ~op:`BVSLE a (binexp ~op:`BVSUB max b);
+                         ];
+                       applyintrin ~op:`AND
+                         [
+                           binexp ~op:`BVSLT b z;
+                           binexp ~op:`BVSLE (binexp ~op:`BVSUB min b) a;
+                         ];
+                     ])
+            | _ -> Keep)
+        | _ -> Keep)
+    | _ -> Keep
+  in
+  rewrite ~rw_fun e
+
+let rewrite_expr e =
+  e |> Algsimp.normalise |> specific_rewrites |> Algsimp.normalise
+
+let transform (p : Program.proc) =
+  Procedure.map_blocks_nondet
+    (fun (bid, block) ->
+      Block.map ~phi:id
+        (Stmt.map ~f_lvar:id ~f_rvar:id ~f_expr:rewrite_expr)
+        block)
+    p

--- a/lib/transforms/cf_tx.ml
+++ b/lib/transforms/cf_tx.ml
@@ -21,6 +21,9 @@ let simplify_proc_exprs ?visit rewriter p =
 let simplify_proc_exprs_default ?visit p =
   simplify_proc_exprs ?visit Algsimp.alg_simp_rewriter p
 
+let simplify_proc_exprs_readable_default ?visit p =
+  simplify_proc_exprs ?visit Algsimp.readable p
+
 let simplify_proc_spec_exprs ?visit rewriter p =
   let s = Procedure.specification p in
   let s =

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -189,8 +189,8 @@ let repeat_bits ~(copies : int) a =
 let sign_extend ~(extension : int) b =
   create ~size:(b.w + extension) @@ to_signed_bigint b
 
-(* -(2^(size)) *)
+(** smallest signed value computed as -(2^(size)) *)
 let min_value_signed size = shl (one ~size) (of_int ~size (size - 1))
 
-(* 2^(size-1) - 1 *)
-let max_value_signed size = sub (min_value_signed size) (one ~size)
+(** largest signed value computed as 2^(size-1) - 1 *)
+let max_value_signed size = bitnot (min_value_signed size)

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -188,3 +188,9 @@ let repeat_bits ~(copies : int) a =
 (* extend sign bit by [extension] bits *)
 let sign_extend ~(extension : int) b =
   create ~size:(b.w + extension) @@ to_signed_bigint b
+
+(* -(2^(size)) *)
+let min_value_signed size = shl (one ~size) (of_int ~size (size - 1))
+
+(* 2^(size-1) - 1 *)
+let max_value_signed size = sub (min_value_signed size) (one ~size)

--- a/test/cram/basicssa.t
+++ b/test/cram/basicssa.t
@@ -186,7 +186,7 @@ Run on basic irreducible loop example
        goto (%main_entry);
      ];
      block %main_entry { .address = 1876 } [
-       var #4_1:bv64 := bvsub(R31_1:bv64, 0x20:bv64) { .label = "%0000035a" };
+       var #4_1:bv64 := bvadd(R31_1:bv64, 0xffffffffffffffe0:bv64) { .label = "%0000035a" };
        $stack:(bv64->bv8) := store le $stack:(bv64->bv8) #4_1:bv64 R29_1:bv64 64 { .label = "%00000360" };
        $stack:(bv64->bv8) := store le $stack:(bv64->bv8) bvadd(#4_1:bv64, 0x8:bv64) R30_1:bv64 64 { .label = "%00000366" };
        var R31_2:bv64 := #4_1:bv64 { .label = "%0000036a" };

--- a/test/cram/cfa_reduction.t
+++ b/test/cram/cfa_reduction.t
@@ -12,8 +12,8 @@
      block %block [
        var v:bool := true;
        var v_2:bool := booland(v:bool, boolnot(bvult(a:bv64, 0x0:bv64)));
-       var x_6:bv64 := if v_2:bool then bvadd(a:bv64, 0x1:bv64) else bvsub(a:bv64,
-        0x1:bv64);
+       var x_6:bv64 := if v_2:bool then bvadd(a:bv64, 0x1:bv64) else bvadd(a:bv64,
+        0xffffffffffffffff:bv64);
        var c:bv64 := x_6:bv64;
        return;
      ]

--- a/test/cram/expr_smt.t
+++ b/test/cram/expr_smt.t
@@ -85,7 +85,7 @@ Check concat rewrites work
   ---
   >      $R28:bv64 := bvor(bvand(sign_extend(63,
   >        extract(32,31, var1_4206396_bv64:bv64)), 0xffffffff00000000:bv64),
-  >       bvand(var1_4206396_bv64:bv64, 0xffffffff:bv64, 0xffffffff:bv64));
+  >       bvand(var1_4206396_bv64:bv64, 0xffffffff:bv64));
   87,88c23
   <      $R0:bv64 := bvor(var1_4206400_bv64:bv64,
   <       bvshl(var2_4206400_bv64:bv64, 0x0:bv64));

--- a/test/cram/linear_copy.t
+++ b/test/cram/linear_copy.t
@@ -8,7 +8,7 @@
   (dump-il after.il)
 
   $ diff before.il after.il
-  7,9c7,11
+  7,9c7,10
   <      (var c:bv64=o, var d:bv64=p) := call @loop(x=b:bv64, y=b:bv64);
   <      (var e:bv64=o) := call @cross(a=d:bv64, b=bvadd(d:bv64, 0x1:bv64));
   <      (var f:bv64 := bvadd(0x1:bv64, c:bv64), var g:bv64 := bvadd(0x1:bv64, e:bv64));
@@ -16,45 +16,44 @@
   >      (var c:bv64=o, var d:bv64=p) := call @loop(x=a:bv64, y=a:bv64);
   >      (var e:bv64=o) := call @cross(a=bvadd(a:bv64, 0x1:bv64),
   >         b=bvadd(a:bv64, 0x2:bv64));
-  >      (var f:bv64 := bvadd(0x1:bv64, c:bv64),
-  >       var g:bv64 := bvadd(0x1:bv64, a:bv64, 0x1:bv64));
-  11c13
+  >      (var f:bv64 := bvadd(0x1:bv64, c:bv64), var g:bv64 := bvadd(a:bv64, 0x2:bv64));
+  11c12
   <      var z:bool := y:bool;
   ---
   >      var z:bool := x:bool;
-  25,26c27,28
+  25,26c26,27
   <    block %f_c ( var y_3:bv64 := phi(%f_a -> y_1:bv64, %f_b -> y_2:bv64) ) [
   <      var w_1:bv64 := y_3:bv64;
   ---
   >    block %f_c ( var y_3:bv64 := phi(%f_a -> x:bv64, %f_b -> x:bv64) ) [
   >      var w_1:bv64 := x:bv64;
-  29,30c31,32
+  29,30c30,31
   <    block %f_d ( var y_4:bv64 := phi(%f_a -> y_1:bv64, %f_b -> y_2:bv64) ) [
   <      (var w_2:bv64=o, var p:bv64=p) := call @g(x=y_4:bv64);
   ---
   >    block %f_d ( var y_4:bv64 := phi(%f_a -> x:bv64, %f_b -> x:bv64) ) [
   >      (var w_2:bv64=o, var p:bv64=p) := call @g(x=x:bv64);
-  33,34c35,36
+  33,34c34,35
   <    block %f_return ( var w_3:bv64 := phi(%f_c -> w_1:bv64, %f_d -> w_2:bv64) ) [
   <      var o:bv64 := w_3:bv64;
   ---
   >    block %f_return ( var w_3:bv64 := phi(%f_c -> x:bv64, %f_d -> x:bv64) ) [
   >      var o:bv64 := x:bv64;
-  45,46c47,48
+  45,46c46,47
   <    block %g_return ( var y_3:bv64 := phi(%g_a -> y_1:bv64, %g_b -> y_2:bv64) ) [
   <      (var o:bv64 := x:bv64, var p:bv64 := y_3:bv64);
   ---
   >    block %g_return ( var y_3:bv64 := phi(%g_a -> x:bv64, %g_b -> x:bv64) ) [
   >      (var o:bv64 := x:bv64, var p:bv64 := x:bv64);
-  61c63
+  61c62
   <      var y_2:bv64 := phi(%f_entry -> y_1:bv64, %f_a -> y_3:bv64)
   ---
   >      var y_2:bv64 := phi(%f_entry -> y_1:bv64, %f_a -> y_1:bv64)
-  64c66
+  64c65
   <      var y_3:bv64 := y_2:bv64;
   ---
   >      var y_3:bv64 := bvadd(y:bv64, 0x1:bv64);
-  69,70c71,75
+  69,70c70,74
   <      var y_4:bv64 := phi(%f_entry -> y_1:bv64, %f_a -> y_3:bv64)
   <    ) [ (var o:bv64 := x_4:bv64, var p:bv64 := y_4:bv64); return; ]
   ---
@@ -63,7 +62,7 @@
   >      (var o:bv64 := x_4:bv64, var p:bv64 := bvadd(y:bv64, 0x1:bv64));
   >      return;
   >    ]
-  79c84
+  79c83
   <    block %ret ( var o_3:bv64 := phi(%a -> o_1:bv64, %b -> o_2:bv64) ) [
   ---
   >    block %ret ( var o_3:bv64 := phi(%a -> a:bv64, %b -> o_2:bv64) ) [


### PR DESCRIPTION
This pr contains a giant ugly pattern match that identifies the semantic meaning of expressions that $PSTATE_x condition flags get assigned. A later PR will use the results to identify branch conditions hopefully! For now the transform just adds attributes to assign statements for debugging.

I also had to touch some of the algebraic simplification code to make the pattern matches slightly less horrible! This included removing a simplification that translated bvadd(a, -k) into bvsub(a, k) if k is a negative constant. I think we probably don't want to keep this as it forces analyses to handle both bvadds and bvsubs all over the place...