### PR TITLE
 consider spec in `remove-unused-decls` pass 

### DIFF
--- a/lib/lang/procedure.ml
+++ b/lib/lang/procedure.ml
@@ -938,3 +938,17 @@ module BlockGraph = struct
         in
         g)
 end
+
+(** Iterator of variables mentioned in specification,
+    {b may repeat equal varibales}. *)
+let free_vars_specification spec =
+  let open Iter in
+  append_l
+    [
+      of_list spec.modifies_globs;
+      of_list spec.captures_globs;
+      of_list spec.requires |> flat_map Expr.BasilExpr.free_vars_iter;
+      of_list spec.ensures |> flat_map Expr.BasilExpr.free_vars_iter;
+      of_list spec.rely |> flat_map Expr.BasilExpr.free_vars_iter;
+      of_list spec.guarantee |> flat_map Expr.BasilExpr.free_vars_iter;
+    ]

--- a/lib/transforms/ssa.ml
+++ b/lib/transforms/ssa.ml
@@ -56,20 +56,26 @@ let intro_ssi_assigns proc (should_lift : Var.t -> bool) =
   in
   Procedure.map_blocks_nondet fix_block proc
 
+(** Delete unused local var declarations and return used global variables.
+    assumes captures/modifies are up to date. *)
 let drop_unused_var_declarations_proc p =
+  let spec = Procedure.specification p in
+  let used = Procedure.free_vars_specification spec |> VarSet.of_iter in
   let used =
     Procedure.fold_blocks_topo_fwd
       (fun acc id bl ->
         Iter.append (Block.read_vars_iter bl) (Block.assigned_vars_iter bl)
         |> Iter.fold (fun acc i -> VarSet.add i acc) acc)
-      VarSet.empty p
+      used p
   in
   Var.Decls.filter_map_inplace
     (fun _ v -> if VarSet.mem v used then Some v else None)
     (Procedure.local_decls p);
   VarSet.filter Var.is_global used
 
+(** Update modsets and delete unused variable definitions *)
 let drop_unused_var_declarations_prog (p : Program.t) =
+  let p = Spec_modifies.set_modsets p in
   let used =
     Program.procs p
     |> Iter.fold

--- a/test/cram/memory_interproc.t
+++ b/test/cram/memory_interproc.t
@@ -52,8 +52,8 @@
   (dump-boogie out.bpl)
 
   $ boogie out.bpl
-  out.bpl(296,5): Error: this assertion could not be proved
+  out.bpl(302,5): Error: this assertion could not be proved
   Execution trace:
-      out.bpl(285,3): b#inputs
+      out.bpl(291,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 1 error

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -23,19 +23,19 @@
   $ boogie out.bpl
   Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(190,3): b#inputs
+      out.bpl(191,3): b#inputs
   Memory Error: Invalid Free (not base address)
   Execution trace:
-      out.bpl(235,3): b#inputs
+      out.bpl(236,3): b#inputs
   Memory Error: Invalid Access
   Execution trace:
-      out.bpl(270,3): b#inputs
+      out.bpl(271,3): b#inputs
   Memory Error: Invalid Access
   Execution trace:
-      out.bpl(319,3): b#inputs
+      out.bpl(320,3): b#inputs
   Memory Error: Memory Leak
   Execution trace:
-      out.bpl(367,3): b#inputs
+      out.bpl(368,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 5 errors
 
@@ -65,25 +65,25 @@
   $ boogie out.bpl
   Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(226,3): b#inputs
+      out.bpl(227,3): b#inputs
   Memory Error: Invalid Free (not base address)
   Execution trace:
-      out.bpl(271,3): b#inputs
+      out.bpl(272,3): b#inputs
   Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(271,3): b#inputs
-  out.bpl(277,5): Error: a precondition for this call could not be proved
-  out.bpl(146,3): Related location: this is the precondition that could not be proved
+      out.bpl(272,3): b#inputs
+  out.bpl(278,5): Error: a precondition for this call could not be proved
+  out.bpl(147,3): Related location: this is the precondition that could not be proved
   Execution trace:
-      out.bpl(271,3): b#inputs
+      out.bpl(272,3): b#inputs
   Memory Error: Invalid Access
   Execution trace:
-      out.bpl(306,3): b#inputs
+      out.bpl(307,3): b#inputs
   Memory Error: Invalid Access
   Execution trace:
-      out.bpl(355,3): b#inputs
+      out.bpl(356,3): b#inputs
   Memory Error: Memory Leak
   Execution trace:
-      out.bpl(403,3): b#inputs
+      out.bpl(404,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 7 errors


### PR DESCRIPTION
This pass is part of the `ssa` batch so it is annoying (and wrong) to delete shared global declarations (i.e. memory) when they're not used in program body but there exist stub procedures which implicitly modify memory.

It would be nice to make the interpretation of absent modsets in the input be "this procedure modifies nothing" but that can be a problem for later (basil doesn't emit modsets).

