### PR TITLE
move `decl_is_` functions and fix unused warning

### DIFF
--- a/lib/lang/program.ml
+++ b/lib/lang/program.ml
@@ -23,11 +23,6 @@ let pp_stmt fmt s = Format.pp_print_string fmt (show_stmt s)
 
 module DeclsList = Bincaml_util.Indexed_list.Make (ID)
 
-let decl_is_typ = function Type _ -> true | _ -> false
-let decl_is_func = function Function _ -> true | _ -> false
-let decl_is_var = function Variable _ -> true | _ -> false
-let decl_is_proc = function Procedure _ -> true | _ -> false
-
 let decl_binding = function
   | Type { binding } -> binding
   | Variable { binding } -> Var.name binding
@@ -179,9 +174,13 @@ let get_id_by_name name prog = prog.global_names.get_id name
 let add_decl
     ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
       `Append) p decl =
+  let decl_is_func = function Function _ -> true | _ -> false
+  let decl_is_var = function Variable _ -> true | _ -> false
+  let decl_is_proc = function Procedure _ -> true | _ -> false
   let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k in
   let procs_before _ k = decl_is_proc k in
   let funcs_before _ k = decl_is_func k in
+
   let d = p.global_names.decl_or_get (decl_binding decl) in
   let declarations =
     match at with

--- a/lib/lang/program.ml
+++ b/lib/lang/program.ml
@@ -175,11 +175,11 @@ let add_decl
     ?(at : [ `Append | `Prepend | `BeforeVars | `BeforeFuncs | `BeforeProcs ] =
       `Append) p decl =
   let decl_is_func = function Function _ -> true | _ -> false
-  let decl_is_var = function Variable _ -> true | _ -> false
-  let decl_is_proc = function Procedure _ -> true | _ -> false
-  let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k in
-  let procs_before _ k = decl_is_proc k in
-  let funcs_before _ k = decl_is_func k in
+  and decl_is_var = function Variable _ -> true | _ -> false
+  and decl_is_proc = function Procedure _ -> true | _ -> false in
+  let vars_before _ k = decl_is_proc k || decl_is_func k || decl_is_var k
+  and procs_before _ k = decl_is_proc k
+  and funcs_before _ k = decl_is_func k in
 
   let d = p.global_names.decl_or_get (decl_binding decl) in
   let declarations =


### PR DESCRIPTION
by deleting unused `decl_is_typ` function

```
File "lib/lang/program.ml", line 26, characters 4-15:
26 | let decl_is_typ = function Type _ -> true | _ -> false
         ^^^^^^^^^^^
Warning 32 [unused-value-declaration]: unused value decl_is_typ.
```