### PR TITLE
docs/nix: remove odig references

### DIFF
--- a/bincaml.opam
+++ b/bincaml.opam
@@ -44,8 +44,8 @@ depends: [
   "kittyimg"
   "terminal_size"
   "ocamlformat" {= "0.29.0" & with-dev-setup}
-  "ocaml-lsp-server" {with-dev-setup}
   "odoc-driver" {with-doc}
+  "sherlodoc" {with-doc}
   "ppx_expect"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/docs/contributing.mld
+++ b/docs/contributing.mld
@@ -392,28 +392,28 @@ Also consider reviewing the {{:https://ocaml.org/manual/5.3/index.html}OCaml man
 
 {4 OCaml code search }
 
-opam package Search by type signature: {{:https://doc.sherlocode.com}https://doc.sherlocode.com}
+Opam package search by type signature or name: {{:https://doc.sherlocode.com}https://doc.sherlocode.com}
 
-full source search of opam reposotiry {{:https://sherlocode.com/}https://sherlocode.com/}
+Full source search of opam repository: {{:https://sherlocode.com/}https://sherlocode.com/}
 
+We also host docs for Bincaml and its dependencies: {: https://uq-pac.github.io/bincaml/index.html}
 
 {3 Setting up ocaml: }
 
 We recommend you install the language server and dev setup packages:
 
 {v
-opam install ocaml-lsp-server
-opam install --deps-only --with-dev-setup .
+opam install --deps-only --with-dev-setup --with-test .
 v}
 
-[--with-dev-setup] includes [ocamlformat], [odig], [sherlodoc] this is useful for documentation search.
+[--with-dev-setup] includes [ocamlformat] and [ocaml-lsp-server] which are useful for development.
 
-Use the following to build and open the documentation page for an installed package, here [containers]:
+Use the following to build the documentation for the bincaml projects and other packages in the switch:
 
 {v
-odig doc containers
+dune build @doc-new && python3 -m http.server -d _build/default/_doc_new/html/docs
 v}
-
+You will then be able to view the docs at <http://127.0.0.1:8000/>.
 
 It is good practice to hide implementations by interfaces, however in practice this often requires
 a significant amount of code rewriting to define the module and its interface separately.

--- a/docs/contributing.mld
+++ b/docs/contributing.mld
@@ -403,17 +403,16 @@ We also host docs for Bincaml and its dependencies: {: https://uq-pac.github.io/
 We recommend you install the language server and dev setup packages:
 
 {v
+opam install ocaml-lsp-server
 opam install --deps-only --with-dev-setup --with-test .
 v}
-
-[--with-dev-setup] includes [ocamlformat] and [ocaml-lsp-server] which are useful for development.
 
 Use the following to build the documentation for the bincaml projects and other packages in the switch:
 
 {v
-dune build @doc-new && python3 -m http.server -d _build/default/_doc_new/html/docs
+dune build @doc-new _build/default/_doc_new/html/docs
 v}
-You will then be able to view the docs at <http://127.0.0.1:8000/>.
+You will then be able to view the docs by opening `_build/default/_doc_new/html/docs/index.html`.
 
 It is good practice to hide implementations by interfaces, however in practice this often requires
 a significant amount of code rewriting to define the module and its interface separately.

--- a/dune-project
+++ b/dune-project
@@ -65,8 +65,8 @@
   kittyimg
   terminal_size
   (ocamlformat (and (= 0.29.0) :with-dev-setup))
-  (ocaml-lsp-server :with-dev-setup)
   (odoc-driver :with-doc)
+  (sherlodoc :with-doc)
   ppx_expect
   (alcotest :with-test))
  (tags (program-analysis)))

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -48,7 +48,6 @@
   z3-bin, # custom name for z3 binary, since `z3` is the ocaml library
 
   # dev:
-  # , odig
   # , sherlodoc
   # , ocaml-lsp-server
   # , ocamlformat

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,7 +11,6 @@
   capstone_arm64_disas,
   odoc,
   odoc-driver,
-  odig,
   ocaml-lsp,
   ocamlformat,
   opam,
@@ -24,7 +23,6 @@ mkShell {
   packages = [
     odoc
     odoc-driver
-    odig
     ocamlformat
   ]
 
@@ -52,25 +50,7 @@ mkShell {
     bincaml_lsp
   ];
 
-  shellHook = ''
-    export ODIG_CACHE_DIR=~/.cache/odig
-
-    ocaml_hash="$(echo "$OCAMLPATH" | sha1sum | cut -d' ' -f1)"
-    if [[ -z "$ocaml_hash" ]]; then
-      echo 'cannot make ocaml hash - cannot cache odig'
-      export ODIG_LIB_DIR="$(mktemp -d)/lib"
-    else
-      export ODIG_LIB_DIR="$ODIG_CACHE_DIR/$ocaml_hash"
-    fi
-
-    if ! [[ -d "$ODIG_LIB_DIR" ]]; then
-      mkdir -p "$ODIG_LIB_DIR"
-      IFS=':' read -ra ADDR <<< "$OCAMLPATH"
-      for i in "''${ADDR[@]}"; do
-        ln -sf $i/* "$ODIG_LIB_DIR"
-      done
-    fi
-  '' + lib.optionalString isShellForCI ''
+  shellHook = lib.optionalString isShellForCI ''
     opam init --bare --disable-sandboxing $(mktemp -d) --quiet --no --no-setup
   '';
 }


### PR DESCRIPTION
thanks again to eris for spotting this after odig was removed in https://github.com/UQ-PAC/bincaml/pull/254