### PR TITLE
Error context

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -8,6 +8,8 @@ open Bincaml
 let () = Printexc.record_backtrace true
 let () = Script.printer ()
 
+module E = Bincaml_util.Errors
+
 let kittyimg dotfile =
   CCIO.File.with_temp ~prefix:"bincaml_repl_cfg" ~suffix:".png" (fun pngfile ->
       let pngfile = ".png" in
@@ -233,9 +235,11 @@ let run_script ~verb fname =
   try
     let _ = Script.of_chan_2 ~fname chan in
     Ok ()
-  with e ->
-    Logs.debug (fun m -> m "%s" @@ Printexc.get_backtrace ());
-    Error (Printexc.to_string e)
+  with
+  | Errors.BincamlError e -> Error (Format.asprintf "%a" Errors.pp_bincamlerr e)
+  | e ->
+      Logs.debug (fun m -> m "%s" @@ Printexc.get_backtrace ());
+      Error (Printexc.to_string e)
 
 let run_il ~verb fname =
   if verb then Logs.set_level (Some Logs.Debug);

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -72,8 +72,8 @@ let repl ~verb ~echo_cmd =
             let fname = Script.P.(singleton string c) in
             CCIO.with_in fname (fun c ->
                 try Script.of_chan_2 ~fname ~st c
-                with Script.ReplError _ as exn ->
-                  print_endline @@ Script.print_repl_error exn;
+                with exn ->
+                  print_endline @@ Printexc.to_string exn;
                   st)),
           "fname.sexp",
           "Interpret a script" );
@@ -231,9 +231,11 @@ let run_script ~verb fname =
   if verb then Logs.set_level (Some Logs.Debug);
   with_in_or_stdin fname @@ fun chan ->
   try
-    let _ = Script.of_chan_2 chan in
+    let _ = Script.of_chan_2 ~fname chan in
     Ok ()
-  with e -> Error (Printexc.to_string e)
+  with e ->
+    Logs.debug (fun m -> m "%s" @@ Printexc.get_backtrace ());
+    Error (Printexc.to_string e)
 
 let run_il ~verb fname =
   if verb then Logs.set_level (Some Logs.Debug);

--- a/lib/lang/attrib.ml
+++ b/lib/lang/attrib.ml
@@ -129,5 +129,7 @@ let find_int_opt k (e : t option) =
   | `Integer i -> Some i
   | _ -> None
 
+let get_location a = StringMap.find_opt location_key a |> Option.map loc_of_attr
+
 let find_loc_opt (e : t option) =
   find_opt location_key e |> Option.map loc_of_attr

--- a/lib/lang/attrib.ml
+++ b/lib/lang/attrib.ml
@@ -1,4 +1,5 @@
 open Common
+open Bincaml_util.Errors
 
 (** associative datastructure for attributes *)
 
@@ -64,9 +65,6 @@ let to_string ?show_internal e =
   attrib_pretty ?show_internal e |> Containers_pp.Pretty.to_string ~width:80
 
 let empty : attrib_map = StringMap.empty
-
-type loc = int * int
-(** a text token range; beginchar, endchar*)
 
 let attr_of_loc l =
   let s, e = l in

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -217,10 +217,9 @@ let type_applied (funtype : Types.t) (args : Types.t list) =
 
   let funt = Hm_types.curry_f st args rt in
   let ft = Hm_types.ty_of_basil st funtype in
-  try
-    Unification.unify st ~pos:[%here] ft funt |> ignore;
-    Ok (Hm_types.to_basil rt)
-  with Hm_types.TypeErr e -> Error e
+  Errors.to_result @@ fun () ->
+  Unification.unify st ~pos:[%here] ft funt |> ignore;
+  Hm_types.to_basil rt
 
 (** Apply type inference to a program and return a fully type-annotated copy of
     the program. *)

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -3,7 +3,8 @@
 open Common
 open Abstract_expr
 
-exception TypeErr of string
+let type_err ?location msg =
+  Errors.BincamlError (Errors.error ?input_location:location msg TypeError)
 
 open struct
   let fix = TypeExpr.fix
@@ -106,10 +107,12 @@ let scheme_to_string = function
   | Forall (tl, t) -> List.to_string ID.to_string tl ^ ". " ^ type_to_string t
 
 let rec to_basil (t : TypeExpr.t) : Types.t =
-  let wrapped t f =
-    try f ()
-    with TypeErr e ->
-      raise (TypeErr ("error in " ^ (type_to_string @@ t) ^ ": " ^ e))
+  let wrapped e f =
+    Errors.update_error
+      (Errors.push_message
+      @@ Errors.error_message ("conversion of " ^ type_to_string @@ t) TypeError
+      )
+      f
   in
   let open Types in
   wrapped t @@ fun () ->
@@ -121,7 +124,7 @@ let rec to_basil (t : TypeExpr.t) : Types.t =
   | TypeConstr ([ w ], "bv") -> (
       match is_nat_val_type w with
       | Some i -> Bitvector i
-      | None -> raise (TypeErr ("bitvector unresolved: " ^ type_to_string t)))
+      | None -> raise (type_err ("bitvector unresolved: " ^ type_to_string t)))
   | TypeConstr ([], "unit") -> Unit
   | TypeConstr ([], "bool") -> Boolean
   | TypeConstr ([], "int") -> Integer

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -108,10 +108,13 @@ let scheme_to_string = function
 
 let rec to_basil (t : TypeExpr.t) : Types.t =
   let wrapped e f =
-    Errors.update_ctx
-      ~ctx_info:
-        (Errors.context_message ~msg:"type converted to basil"
-           (type_to_string @@ t))
+    Errors.update_error
+      (fun m ->
+        Errors.add_error_context
+          ~ctx_info:
+            (Errors.context_message ~msg:"type converted to basil"
+               (type_to_string @@ t))
+          m)
       f
   in
   let open Types in

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -4,7 +4,7 @@ open Common
 open Abstract_expr
 
 let type_err ?location msg =
-  Errors.BincamlError (Errors.error ?input_location:location msg TypeError)
+  Errors.BincamlError (Errors.error ?ctx_info:location msg TypeError)
 
 open struct
   let fix = TypeExpr.fix
@@ -108,10 +108,10 @@ let scheme_to_string = function
 
 let rec to_basil (t : TypeExpr.t) : Types.t =
   let wrapped e f =
-    Errors.update_error
-      (Errors.push_message
-      @@ Errors.error_message ("conversion of " ^ type_to_string @@ t) TypeError
-      )
+    Errors.update_ctx
+      ~ctx_info:
+        (Errors.context_message ~msg:"type converted to basil"
+           (type_to_string @@ t))
       f
   in
   let open Types in

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -112,6 +112,16 @@ let scheme_of_intrin st ?(visit_constraint = fun a -> ()) (gen : ID.generator)
       curry_f st [ m; a; b ] m
   | `Cases -> fv ()
 
+let add_err_ctx loc f =
+  match loc with
+  | None -> f ()
+  | Some loc ->
+      Errors.update_error (Errors.update_message ~input_location:loc) f
+
+let loc_e e =
+  Expr.BasilExpr.unfix e |> Expr.AbstractExpr.get_attrib |> Attrib.get_location
+  |> Option.map (fun l -> Errors.location_loc ~msg:"expression" l)
+
 let do_infer st ~visit_constraint
     (infer :
       univ:string ->
@@ -119,6 +129,7 @@ let do_infer st ~visit_constraint
       Program.e ->
       scheme TypeExpr.TCtx.t ->
       AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
+  add_err_ctx (loc_e e) @@ fun () ->
   let unify = Unification.unify st
   and curry_f = Hm_types.curry_f st
   and scheme_of_op = scheme_of_op st
@@ -189,9 +200,11 @@ let rec infer_expr st visit_constraint ~univ (hr : Lexing.position) e =
   Logs.debug (fun m ->
       m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
   let t =
-    try
-      do_infer st ~visit_constraint (infer_expr st visit_constraint) univ hr e c
-    with TypeErr m -> raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
+    Errors.update_error
+      (Errors.push_message
+      @@ Errors.error_message (Expr.BasilExpr.to_string e) Errors.TypeError)
+    @@ fun () ->
+    do_infer st ~visit_constraint (infer_expr st visit_constraint) univ hr e c
   in
   t
 
@@ -321,11 +334,17 @@ let do_infer_stmt st visit_constraint p univ ctx stmt =
         { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
 
 let infer_stmt st vc p univ ctx s =
-  try do_infer_stmt st vc p univ ctx s
-  with TypeErr m ->
-    raise
-      (TypeErr
-         (m ^ " " ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
+  let input_location =
+    Stmt.attrib s |> Attrib.get_location
+    |> Option.map (fun l -> Errors.location_loc ~msg:"statement" l)
+  in
+  Errors.update_error
+    (Errors.push_message
+    @@ Errors.error_message ?input_location
+         ("statement:"
+         ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s)
+         TypeError)
+  @@ fun () -> do_infer_stmt st vc p univ ctx s
 
 let infer_block st vc p univ ctx (b : Program.bloc) =
   let _ = infer_phi st vc univ ctx b.phis in

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -113,7 +113,9 @@ let scheme_of_intrin st ?(visit_constraint = fun a -> ()) (gen : ID.generator)
   | `Cases -> fv ()
 
 let add_err_ctx loc f =
-  match loc with None -> f () | Some loc -> Errors.update_ctx ~ctx_info:loc f
+  match loc with
+  | None -> f ()
+  | Some loc -> Errors.update_error (Errors.add_error_context ~ctx_info:loc) f
 
 let loc_e e =
   Expr.BasilExpr.unfix e |> Expr.AbstractExpr.get_attrib |> Attrib.get_location
@@ -331,7 +333,7 @@ let do_infer_stmt st visit_constraint p univ ctx stmt =
         { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
 
 let infer_stmt st vc p univ ctx s =
-  let input_location =
+  let input_location () =
     Stmt.attrib s |> Attrib.get_location
     |> Option.map (fun l -> Errors.location_loc ~msg:"statement" l)
     |> Option.get_or
@@ -339,8 +341,9 @@ let infer_stmt st vc p univ ctx s =
            (Errors.context_message ~msg:"statment"
               (Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
   in
-  Errors.update_ctx ~ctx_info:input_location @@ fun () ->
-  do_infer_stmt st vc p univ ctx s
+  Errors.update_error (fun m ->
+      Errors.add_error_context ~ctx_info:(input_location ()) m)
+  @@ fun () -> do_infer_stmt st vc p univ ctx s
 
 let infer_block st vc p univ ctx (b : Program.bloc) =
   let _ = infer_phi st vc univ ctx b.phis in

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -113,14 +113,11 @@ let scheme_of_intrin st ?(visit_constraint = fun a -> ()) (gen : ID.generator)
   | `Cases -> fv ()
 
 let add_err_ctx loc f =
-  match loc with
-  | None -> f ()
-  | Some loc ->
-      Errors.update_error (Errors.update_message ~input_location:loc) f
+  match loc with None -> f () | Some loc -> Errors.update_ctx ~ctx_info:loc f
 
 let loc_e e =
   Expr.BasilExpr.unfix e |> Expr.AbstractExpr.get_attrib |> Attrib.get_location
-  |> Option.map (fun l -> Errors.location_loc ~msg:"expression" l)
+  |> Option.map (fun l -> Errors.location_loc ~msg:"infer expression" l)
 
 let do_infer st ~visit_constraint
     (infer :
@@ -199,14 +196,14 @@ let rec infer_expr st visit_constraint ~univ (hr : Lexing.position) e =
  fun (c : scheme TypeExpr.TCtx.t) ->
   Logs.debug (fun m ->
       m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
-  let t =
-    Errors.update_error
-      (Errors.push_message
-      @@ Errors.error_message (Expr.BasilExpr.to_string e) Errors.TypeError)
-    @@ fun () ->
+  let f =
+   fun () ->
     do_infer st ~visit_constraint (infer_expr st visit_constraint) univ hr e c
   in
-  t
+  let m =
+    Errors.context_message ~msg:"infer expr" (Expr.BasilExpr.to_string e)
+  in
+  f ()
 
 let infer st visit_constraint ~univ (hr : Lexing.position) e
     (c : scheme TypeExpr.TCtx.t) =
@@ -337,14 +334,13 @@ let infer_stmt st vc p univ ctx s =
   let input_location =
     Stmt.attrib s |> Attrib.get_location
     |> Option.map (fun l -> Errors.location_loc ~msg:"statement" l)
+    |> Option.get_or
+         ~default:
+           (Errors.context_message ~msg:"statment"
+              (Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
   in
-  Errors.update_error
-    (Errors.push_message
-    @@ Errors.error_message ?input_location
-         ("statement:"
-         ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s)
-         TypeError)
-  @@ fun () -> do_infer_stmt st vc p univ ctx s
+  Errors.update_ctx ~ctx_info:input_location @@ fun () ->
+  do_infer_stmt st vc p univ ctx s
 
 let infer_block st vc p univ ctx (b : Program.bloc) =
   let _ = infer_phi st vc univ ctx b.phis in

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -202,10 +202,10 @@ let rec infer_expr st visit_constraint ~univ (hr : Lexing.position) e =
    fun () ->
     do_infer st ~visit_constraint (infer_expr st visit_constraint) univ hr e c
   in
-  let m =
+  let info =
     Errors.context_message ~msg:"infer expr" (Expr.BasilExpr.to_string e)
   in
-  f ()
+  Errors.update_error (fun m -> Errors.add_error_context ~ctx_info:info m) f
 
 let infer st visit_constraint ~univ (hr : Lexing.position) e
     (c : scheme TypeExpr.TCtx.t) =

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -57,7 +57,7 @@ let solve_constraints st ~max_iters cls =
     | [] -> ()
     | _ when tries > max_iters ->
         raise
-          (TypeErr
+          (type_err
              ("Gave up solving bitvec constraints with remaining:\n" ^ show cs))
     | cs ->
         let remaining =

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -5,17 +5,17 @@ open Abstract_expr
 
 let type_error st a b =
   let a, b = TypeExpr.(find st a, find st b) in
-  raise
-    (Hm_types.TypeErr
-       ("type_error: " ^ Hm_types.type_to_string a ^ " <> "
-      ^ Hm_types.type_to_string b))
+  Errors.raise_error
+    ("type_error: " ^ Hm_types.type_to_string a ^ " <> "
+   ^ Hm_types.type_to_string b)
+    TypeError
 
 let recursion_error st a b =
   let b = TypeExpr.find st b in
-  raise
-    (Hm_types.TypeErr
-       ("recursive: tvar " ^ ID.to_string a ^ " occurs in "
-      ^ Hm_types.type_to_string b))
+  Errors.raise_error
+    ("recursive: tvar " ^ ID.to_string a ^ " occurs in "
+   ^ Hm_types.type_to_string b)
+    TypeError
 
 (** Check for type recursion: recursion is failure. *)
 let occurs_in a b =

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -602,7 +602,7 @@ module BasilASTLoader = struct
     | Attr_Str s -> `String (trans_str s)
 
   and trans_attrib_set ~binds p_st (atrs : attribSet) :
-      Attrib.loc option * Attrib.attrib_map =
+      Bincaml_util.Errors.loc option * Attrib.attrib_map =
     match atrs with
     | AttribSet_Empty -> (None, StringMap.empty)
     | AttribSet_Some (BeginRec (l, _), attrKeyValue, EndRec (r, _)) ->

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -602,7 +602,7 @@ module BasilASTLoader = struct
     | Attr_Str s -> `String (trans_str s)
 
   and trans_attrib_set ~binds p_st (atrs : attribSet) :
-      Bincaml_util.Errors.loc option * Attrib.attrib_map =
+      Errors.loc option * Attrib.attrib_map =
     match atrs with
     | AttribSet_Empty -> (None, StringMap.empty)
     | AttribSet_Some (BeginRec (l, _), attrKeyValue, EndRec (r, _)) ->
@@ -1475,59 +1475,37 @@ end
 
 exception ILBParseError of { input : Pp_loc.Input.t; lexbuf : Lexing.lexbuf }
 
-let format_ploc input =
- fun f ->
-  Pp_loc.setup_highlight_tags f
-    ~single_line_underline:
-      {
-        open_tag =
-          (fun _ -> Format.ANSI_codes.string_of_style_list [ `Bold; `FG `Red ]);
-        close_tag = (fun _ -> Format.ANSI_codes.string_of_style `Reset);
-      }
-    ();
+let () = Errors.regprinter ()
 
-  Pp_loc.pp ~input ~max_lines:5 f
-
-let show_ilbparseerror e =
-  match e with
-  | LoadError { input = None; msg } -> msg
-  | LoadError
-      { input = Some input; msg; token_char_offset_range = Some (btok, etok) }
-    ->
-      let o =
-        Format.asprintf "Error: %s%a%a" msg Format.pp_print_newline ()
-          (format_ploc input)
-          [ (Pp_loc.Position.of_offset btok, Pp_loc.Position.of_offset etok) ]
-      in
-      o
-  | ILBParseError { input; lexbuf } ->
-      let loc =
-        [
-          ( Pp_loc.Position.of_lexing @@ Lexing.lexeme_start_p lexbuf,
-            Pp_loc.Position.of_lexing @@ Lexing.lexeme_end_p lexbuf );
-        ]
-      in
-      let fname = (Lexing.lexeme_end_p lexbuf).pos_fname in
-      let lnum = (Lexing.lexeme_end_p lexbuf).pos_lnum in
-      let o =
-        Format.asprintf "Parse error:  %s:%d%a%a" fname lnum
-          Format.pp_print_newline () (format_ploc input) loc
-      in
-      o
-  | _ -> failwith "diff error"
-
-let () =
-  Printexc.register_printer (function
-    | BasilIR.BNFC_Util.Parse_error (b, e) ->
-        let fname = b.pos_fname in
-        let x = b.pos_lnum in
-        let col = b.pos_cnum - b.pos_bol in
-        Some (Printf.sprintf "Parse error in \"%s\" line %d col %d" fname x col)
-    | ILBParseError _ as e -> Some (show_ilbparseerror e)
-    | LoadError _ as e -> Some (show_ilbparseerror e)
-    | _ -> None (* for other exceptions *))
+let conv_error_info (f : unit -> 'a) =
+  Errors.protect_with_info
+    (function
+      | BasilIR.BNFC_Util.Parse_error (b, e) ->
+          let input_location =
+            Errors.location_position ~msg:"error token" (b, e)
+          in
+          Some
+            (Errors.error ~input_location "bnfc parse error" Errors.InputError)
+      | ILBParseError { input; lexbuf } ->
+          let input_location =
+            Errors.location_lexing ~msg:"next token" lexbuf
+          in
+          Some (Errors.error ~input ~input_location "parse error" InputError)
+      | LoadError { token_char_offset_range; msg; input = i } ->
+          let input_location =
+            Option.map (Errors.location_loc ~msg) token_char_offset_range
+          in
+          Some (Errors.error ?input_location "load error" InputError)
+      | Errors.BincamlError e -> Some e
+      | other ->
+          Some
+            (Errors.error_of_exn other
+            |> Errors.push_message
+                 (Errors.error_message "parse error" InputError)))
+    f
 
 let concrete_prog_ast_of_channel ?input ?filename c =
+  conv_error_info @@ fun () ->
   let open BasilIR in
   let input = Option.get_or ~default:(Pp_loc.Input.in_channel c) input in
   let lexbuf = Lexing.from_channel ~with_positions:true c in
@@ -1537,6 +1515,7 @@ let concrete_prog_ast_of_channel ?input ?filename c =
 
 let concrete_prog_ast_of_string ?input ?filename str =
   let open BasilIR in
+  conv_error_info @@ fun () ->
   let input = Option.get_or ~default:(Pp_loc.Input.string str) input in
   let lexbuf = Lexing.from_string ~with_positions:true str in
   filename |> Option.iter (fun f -> Lexing.set_filename lexbuf f);
@@ -1544,6 +1523,7 @@ let concrete_prog_ast_of_string ?input ?filename str =
   with ParBasilIR.Error -> raise (ILBParseError { input; lexbuf })
 
 let parse_proc ?input lexbuf =
+  conv_error_info @@ fun () ->
   let open BasilIR in
   try ParBasilIR.pDecl LexBasilIR.token lexbuf
   with ParBasilIR.Error -> (
@@ -1554,6 +1534,7 @@ let parse_proc ?input lexbuf =
     | None -> raise (BNFC_Util.Parse_error (start_pos, end_pos)))
 
 let parse_expr ?input lexbuf =
+  conv_error_info @@ fun () ->
   let open BasilIR in
   try ParBasilIR.pExpr LexBasilIR.token lexbuf
   with ParBasilIR.Error -> (
@@ -1564,17 +1545,20 @@ let parse_expr ?input lexbuf =
     | None -> raise (BNFC_Util.Parse_error (start_pos, end_pos)))
 
 let parse_proc_string st c =
+  conv_error_info @@ fun () ->
   let lexbuf = Lexing.from_string ~with_positions:true c in
   let input = Pp_loc.Input.string c in
   let proc = parse_proc ~input lexbuf in
   BasilASTLoader.trans_definition st proc
 
 let parse_proc_channel st c =
+  conv_error_info @@ fun () ->
   let lexbuf = Lexing.from_channel ~with_positions:true c in
   let proc = parse_proc lexbuf in
   BasilASTLoader.trans_definition st proc
 
 let parse_expr_string s =
+  conv_error_info @@ fun () ->
   let lexbuf = Lexing.from_string ~with_positions:true s in
   let input = Pp_loc.Input.string s in
   let e = parse_expr ~input lexbuf in
@@ -1582,6 +1566,7 @@ let parse_expr_string s =
 
 let protect_parse parsefun =
   let parse input lexbuf =
+    conv_error_info @@ fun () ->
     let open BasilIR in
     try parsefun LexBasilIR.token lexbuf
     with ParBasilIR.Error -> (
@@ -1596,6 +1581,7 @@ let protect_parse parsefun =
 (** Loads a single block in isolation in a proceudre and returns it, does not
     support procedure calls or returns *)
 let load_single_block_proc ?(proc = "<proc>") ?input lexbuf =
+  conv_error_info @@ fun () ->
   let block = protect_parse BasilIR.ParBasilIR.pBlock input lexbuf in
   let prog, proc = Program.create_single_proc ~name:proc () in
   let st = { prog; params_order = Hashtbl.create 30; curr_proc = Some proc } in
@@ -1636,16 +1622,19 @@ let load_single_block ?proc ~input lexbuf =
   block
 
 let parse_single_block_proc ?proc s =
+  conv_error_info @@ fun () ->
   let lexbuf = Lexing.from_string ~with_positions:true s in
   let input = Pp_loc.Input.string s in
   load_single_block_proc ?proc ~input lexbuf
 
 let parse_single_block s : Program.bloc =
+  conv_error_info @@ fun () ->
   let lexbuf = Lexing.from_string ~with_positions:true s in
   let input = Pp_loc.Input.string s in
   load_single_block ~input lexbuf
 
 let ast_of_concrete_ast ?(lst : load_st option) ~name m =
+  conv_error_info @@ fun () ->
   Trace_core.with_span ~__FILE__ ~__LINE__ "convert-concrete-ast" @@ fun f ->
   let e = BasilASTLoader.trans_program ?lst ~name m in
   Program.procs e.prog |> Iter.map snd |> Iter.iter Lang.Check.wf_checks;
@@ -1653,6 +1642,7 @@ let ast_of_concrete_ast ?(lst : load_st option) ~name m =
 
 let ast_of_string ?(lst : load_st option) ?__LINE__ ?__FILE__ ?__FUNCTION__
     string =
+  conv_error_info @@ fun () ->
   let name =
     let open Option.Infix in
     let* line = __LINE__ >|= Int.to_string in
@@ -1668,6 +1658,7 @@ let ast_of_string ?(lst : load_st option) ?__LINE__ ?__FILE__ ?__FUNCTION__
     raise (LoadError { input = Some input; token_char_offset_range; msg })
 
 let ast_of_channel ?(lst : load_st option) ?input fname c =
+  conv_error_info @@ fun () ->
   let m =
     Trace_core.with_span ~__FILE__ ~__LINE__ "load-concrete-ast" @@ fun f ->
     let m = concrete_prog_ast_of_channel ?input ~filename:fname c in
@@ -1678,6 +1669,7 @@ let ast_of_channel ?(lst : load_st option) ?input fname c =
     raise (LoadError { input; token_char_offset_range; msg })
 
 let ast_of_fname ?(lst : load_st option) fname =
+  conv_error_info @@ fun () ->
   IO.with_in fname (fun c ->
       ast_of_channel ?lst ~input:(Pp_loc.Input.file fname) fname c)
 
@@ -1707,10 +1699,8 @@ proc @main_4196260 () -> ()
   [%expect.unreachable]
 [@@expect.uncaught_exn
   {|
-  ( "Error: no such block: %main_7\
-   \n12 |     goto(%main_7, %main_11);\
-   \n              \027[1;31m^^^^^^^\027[0m\
-   \n")
+  ( "load error : input error\
+   \nno such block: %main_7 at ")
   |}]
 
 let%expect_test "missing proc" =
@@ -1735,10 +1725,8 @@ proc @main_4196260 () -> ()
   [%expect.unreachable]
 [@@expect.uncaught_exn
   {|
-  ( "Error: no such procedure: @cat_4198032\
-   \n7 |     call @cat_4198032();\
-   \n             \027[1;31m^^^^^^^^^^^^\027[0m\
-   \n")
+  ( "load error : input error\
+   \nno such procedure: @cat_4198032 at ")
   |}]
 
 let%expect_test "syntax error" =
@@ -1765,7 +1753,8 @@ proc @main_4196260 () -> ()
   [%expect.unreachable]
 [@@expect.uncaught_exn
   {|
-  ( "Parse error:  <string>:8\
+  ( "parse error : input error\
+   \nnext token\
    \n8 |     :bv1 := 1:bv1;\
    \n        \027[1;31m^\027[0m\
    \n")

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -1475,8 +1475,6 @@ end
 
 exception ILBParseError of { input : Pp_loc.Input.t; lexbuf : Lexing.lexbuf }
 
-let () = Errors.regprinter ()
-
 let conv_error_info (f : unit -> 'a) =
   Errors.protect_with_info
     (function

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -1479,27 +1479,20 @@ let conv_error_info (f : unit -> 'a) =
   Errors.protect_with_info
     (function
       | BasilIR.BNFC_Util.Parse_error (b, e) ->
-          let input_location =
-            Errors.location_position ~msg:"error token" (b, e)
+          let ctx_info =
+            Errors.location_position ~msg:"error token" (b, Some e)
           in
-          Some
-            (Errors.error ~input_location "bnfc parse error" Errors.InputError)
+          Some (Errors.error ~ctx_info "bnfc parse error" Errors.InputError)
       | ILBParseError { input; lexbuf } ->
-          let input_location =
-            Errors.location_lexing ~msg:"next token" lexbuf
-          in
-          Some (Errors.error ~input ~input_location "parse error" InputError)
+          let ctx_info = Errors.location_lexing ~msg:"next token" lexbuf in
+          Some (Errors.error ~input ~ctx_info "parse error" InputError)
       | LoadError { token_char_offset_range; msg; input = i } ->
-          let input_location =
+          let ctx_info =
             Option.map (Errors.location_loc ~msg) token_char_offset_range
           in
-          Some (Errors.error ?input_location "load error" InputError)
+          Some (Errors.error ?ctx_info "load error" InputError)
       | Errors.BincamlError e -> Some e
-      | other ->
-          Some
-            (Errors.error_of_exn other
-            |> Errors.push_message
-                 (Errors.error_message "parse error" InputError)))
+      | other -> Some (Errors.error_of_exn other))
     f
 
 let concrete_prog_ast_of_channel ?input ?filename c =
@@ -1695,9 +1688,10 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  ( "load error : input error\
+[@@expect.uncaught_exn {|
+  ( "Input error: load error\
+   \n\
+   \nRelated context:\
    \nno such block: %main_7 at ")
   |}]
 
@@ -1721,9 +1715,10 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  ( "load error : input error\
+[@@expect.uncaught_exn {|
+  ( "Input error: load error\
+   \n\
+   \nRelated context:\
    \nno such procedure: @cat_4198032 at ")
   |}]
 
@@ -1749,9 +1744,10 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  ( "parse error : input error\
+[@@expect.uncaught_exn {|
+  ( "Input error: parse error\
+   \n\
+   \nRelated context:\
    \nnext token\
    \n8 |     :bv1 := 1:bv1;\
    \n        \027[1;31m^\027[0m\

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -1688,7 +1688,8 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   ( "Input error: load error\
    \n\
    \nRelated context:\
@@ -1715,7 +1716,8 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   ( "Input error: load error\
    \n\
    \nRelated context:\
@@ -1744,7 +1746,8 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   ( "Input error: parse error\
    \n\
    \nRelated context:\

--- a/lib/script.ml
+++ b/lib/script.ml
@@ -26,6 +26,11 @@ module Sexp = Sexp.Make (SexpLoc)
 
 type errpos = { pos : SexpLoc.loc list; inp : Pp_loc.Input.t }
 
+let errpos_to_error_loc ?fname { inp; pos } =
+  let name = Option.get_or ~default:"script" fname in
+  let pos = List.map (fun (a, b) -> Errors.PPPosition (a, b)) pos in
+  Errors.OtherFile { input = inp; locations = pos; name }
+
 exception ReplError of { msg : string; cmd : string; loc : errpos option }
 
 let print_repl_error = function
@@ -45,6 +50,17 @@ let print_repl_error = function
       in
       s
   | _ -> failwith ""
+
+let conv_repl_error f =
+  Errors.protect_with_info
+    (function
+      | ReplError { msg; cmd; loc = None } ->
+          Some (Errors.error (msg ^ " in cmd (" ^ cmd ^ ")") Error)
+      | ReplError { msg; cmd; loc = Some pos } ->
+          let here = errpos_to_error_loc pos in
+          Some (Errors.error ~here (msg ^ " in cmd (" ^ cmd ^ ")") Unhandled)
+      | o -> None)
+    f
 
 let printer () =
   Printexc.register_printer (function
@@ -194,16 +210,15 @@ let chc_dump_clauses st args =
 
 let load_il st args =
   let largs = P.(list string args) in
-  try
-    List.fold_left
-      (fun acc fname ->
-        let st = Loader.Loadir.ast_of_fname ?lst:acc.load_st fname in
-        { acc with load_st = Some st })
-      { st with load_st = None } largs
-  with (Loader.Loadir.ILBParseError _ | Loader.Loadir.LoadError _) as e ->
-    let msg = Loader.Loadir.show_ilbparseerror e in
-    raise
-      (ReplError { msg; cmd = "load-il " ^ Sexp.to_string args; loc = None })
+  let cmd = "load-il " ^ Sexp.to_string args in
+  Errors.(update_error (push_message @@ error_message cmd Errors.InputError))
+    (fun () ->
+      Errors.wrap_error (fun () ->
+          List.fold_left
+            (fun acc fname ->
+              let st = Loader.Loadir.ast_of_fname ?lst:acc.load_st fname in
+              { acc with load_st = Some st })
+            { st with load_st = None } largs))
 
 let run_transform st args =
   let args = P.(list string args) in
@@ -449,8 +464,7 @@ and atom_cmd ?(cmds = default_cmds) ?(echo_cmd = true) st
               let st = f st args in
               let st = { st with history = i_command :: st.history } in
               st
-          | None ->
-              raise (ReplError { msg = "not a command."; loc = None; cmd })))
+          | None -> Errors.raise_error "not a command." Error))
 
 let of_channel ?st c =
   let st = Option.get_or ~default:init_st st in
@@ -460,6 +474,7 @@ let of_channel ?st c =
   List.fold_left of_cmd st i
 
 let of_chan_2 ?fname ?st channel =
+  conv_repl_error @@ fun () ->
   let lbuf = Lexing.from_channel ~with_positions:true channel in
   let s = Sexp.Decoder.of_lexbuf lbuf in
   let st = ref (Option.get_or ~default:init_st st) in
@@ -468,34 +483,22 @@ let of_chan_2 ?fname ?st channel =
     |> Option.get_or ~default:(Pp_loc.Input.in_channel channel)
   in
   while
-    let b : Sexp.loc option = Sexp.Decoder.last_loc s in
     let sexp = Sexp.Decoder.next s in
     let e : Sexp.loc option = Sexp.Decoder.last_loc s in
-    let loc =
-      match (b, e) with
-      | Some b, Some e ->
-          Some { pos = [ e ]; inp = Pp_loc.Input.in_channel channel }
-      | _, Some e -> Some { pos = [ e ]; inp }
-      | Some e, _ -> Some { pos = [ e ]; inp }
-      | None, None -> None
-    in
+    let loc = match e with Some e -> Some { pos = [ e ]; inp } | _ -> None in
+    let here = Option.map (errpos_to_error_loc ?fname) loc in
     match sexp with
-    | Yield sexp -> (
-        try
+    | Yield sexp ->
+        let f () =
           st := of_cmd !st sexp;
           true
-        with
-        | ReplError { msg; cmd; loc = None } ->
-            raise (ReplError { msg; cmd; loc })
-        | err ->
-            Logs.debug (fun m -> m "%s" (Printexc.get_backtrace ()));
-            raise
-              (ReplError
-                 {
-                   msg = Printexc.to_string err;
-                   loc;
-                   cmd = Sexp.to_string sexp;
-                 }))
+        in
+        Errors.protect_with_info
+          (function
+            | ReplError { msg; cmd; loc = None } ->
+                Some (Errors.error ?here (msg ^ " in cmd " ^ cmd) Error)
+            | err -> Some (Errors.error_of_exn ?here err))
+          f
     | Fail msg -> raise (ReplError { msg; loc; cmd = "" })
     | End -> false
   do
@@ -504,6 +507,7 @@ let of_chan_2 ?fname ?st channel =
   !st
 
 let of_str st (e : string) =
+  conv_repl_error @@ fun () ->
   let str_comment =
     try String.index_from e 0 ';' with Not_found -> String.length e
   in

--- a/lib/script.ml
+++ b/lib/script.ml
@@ -28,8 +28,9 @@ type errpos = { pos : SexpLoc.loc list; inp : Pp_loc.Input.t }
 
 let errpos_to_error_loc ?fname { inp; pos } =
   let name = Option.get_or ~default:"script" fname in
-  let pos = List.map (fun (a, b) -> Errors.PPPosition (a, b)) pos in
-  Errors.OtherFile { input = inp; locations = pos; name }
+  pos |> List.head_opt
+  |> Option.map @@ fun pos ->
+     Errors.location_pp_position ~input:(Input inp) ~msg:name pos
 
 exception ReplError of { msg : string; cmd : string; loc : errpos option }
 
@@ -58,7 +59,10 @@ let conv_repl_error f =
           Some (Errors.error (msg ^ " in cmd (" ^ cmd ^ ")") Error)
       | ReplError { msg; cmd; loc = Some pos } ->
           let here = errpos_to_error_loc pos in
-          Some (Errors.error ~here (msg ^ " in cmd (" ^ cmd ^ ")") Unhandled)
+          Some
+            (Errors.error ?ctx_info:here
+               (msg ^ " in cmd (" ^ cmd ^ ")")
+               Unhandled)
       | o -> None)
     f
 
@@ -218,7 +222,9 @@ let chc_dump_clauses st args =
 let load_il st args =
   let largs = P.(list string args) in
   let cmd = "load-il " ^ Sexp.to_string args in
-  Errors.(update_error (push_message @@ error_message cmd Errors.InputError))
+  Errors.(
+    update_error
+      (Errors.add_error_context ~ctx_info:(context_message ~msg:"command" cmd)))
     (fun () ->
       Errors.wrap_error (fun () ->
           List.fold_left
@@ -511,7 +517,7 @@ let of_chan_2 ?fname ?st channel =
       | Some e, Some _ -> Some { pos = [ e ]; inp }
       | _ -> None
     in
-    let here = Option.map (errpos_to_error_loc ?fname) loc in
+    let ctx_info = Option.bind loc (errpos_to_error_loc ?fname) in
     match sexp with
     | Yield sexp ->
         let f () =
@@ -521,8 +527,8 @@ let of_chan_2 ?fname ?st channel =
         Errors.protect_with_info
           (function
             | ReplError { msg; cmd; loc = None } ->
-                Some (Errors.error ?here (msg ^ " in cmd " ^ cmd) Error)
-            | err -> Some (Errors.error_of_exn ?here err))
+                Some (Errors.error ?ctx_info (msg ^ " in cmd " ^ cmd) Error)
+            | err -> Some (Errors.error_of_exn ?ctx_info err))
           f
     | Fail msg -> raise (ReplError { msg; loc; cmd = "" })
     | End -> false

--- a/lib/script.ml
+++ b/lib/script.ml
@@ -89,12 +89,19 @@ let print_blocks_topo_fwd chan p =
 type dsl_st = {
   history : Sexp.t list;
   load_st : Loader.Loadir.load_st option;
+  source_files : string list; (* if there is a single exact source file *)
   line : int;
   user_cmds : (string * Sexp.t) StringMap.t;
 }
 
 let init_st =
-  { history = []; load_st = None; line = 0; user_cmds = StringMap.empty }
+  {
+    history = [];
+    load_st = None;
+    line = 0;
+    user_cmds = StringMap.empty;
+    source_files = [];
+  }
 
 let get_prog s =
   s.load_st
@@ -217,7 +224,11 @@ let load_il st args =
           List.fold_left
             (fun acc fname ->
               let st = Loader.Loadir.ast_of_fname ?lst:acc.load_st fname in
-              { acc with load_st = Some st })
+              {
+                acc with
+                load_st = Some st;
+                source_files = fname :: acc.source_files;
+              })
             { st with load_st = None } largs))
 
 let run_transform st args =
@@ -432,8 +443,16 @@ let add_help_cmd cmds =
 
 let default_cmds = add_help_cmd cmds_list
 
+let protect_with_input { source_files } f =
+  match source_files with
+  | [ inp ] -> Errors.update_error (Errors.add_input ~input_file:inp) f
+  | _ ->
+      (* there is not a singular source file *)
+      f ()
+
 let rec of_cmd ?(cmds = default_cmds) ?(echo_cmd = true) st
     (i_command : Containers.Sexp.t) =
+  protect_with_input st @@ fun () ->
   match i_command with
   | `List (`Atom "progn" :: rest) ->
       List.fold_left (of_cmd ~cmds ~echo_cmd) st rest
@@ -478,14 +497,20 @@ let of_chan_2 ?fname ?st channel =
   let lbuf = Lexing.from_channel ~with_positions:true channel in
   let s = Sexp.Decoder.of_lexbuf lbuf in
   let st = ref (Option.get_or ~default:init_st st) in
+  let fname = Option.filter Sys.file_exists fname in
   let inp =
-    Option.map Pp_loc.Input.file fname
+    fname
+    |> Option.map Pp_loc.Input.file
     |> Option.get_or ~default:(Pp_loc.Input.in_channel channel)
   in
   while
     let sexp = Sexp.Decoder.next s in
     let e : Sexp.loc option = Sexp.Decoder.last_loc s in
-    let loc = match e with Some e -> Some { pos = [ e ]; inp } | _ -> None in
+    let loc =
+      match (e, fname) with
+      | Some e, Some _ -> Some { pos = [ e ]; inp }
+      | _ -> None
+    in
     let here = Option.map (errpos_to_error_loc ?fname) loc in
     match sexp with
     | Yield sexp ->

--- a/lib/script.ml
+++ b/lib/script.ml
@@ -223,9 +223,10 @@ let load_il st args =
   let largs = P.(list string args) in
   let cmd = "load-il " ^ Sexp.to_string args in
   Errors.(
-    update_error
-      (Errors.add_error_context ~ctx_info:(context_message ~msg:"command" cmd)))
-    (fun () ->
+    update_error (fun x ->
+        Errors.add_error_context
+          ~ctx_info:(context_message ~msg:"command" cmd)
+          x)) (fun () ->
       Errors.wrap_error (fun () ->
           List.fold_left
             (fun acc fname ->

--- a/lib/util/common.ml
+++ b/lib/util/common.ml
@@ -2,6 +2,7 @@
 
 include Containers
 include Fun
+module Errors = Errors
 
 (** Common collections *)
 

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -12,6 +12,7 @@
   extras
   unicode
   var
+  errors
   ID
   types
   bitvec
@@ -27,6 +28,7 @@
   mtime.clock
   iter
   containers
+  pp_loc
   fix
   containers.unix
   containers.pp

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -35,6 +35,7 @@ let loc_to_position = function
 type location_info = { range : location; description : string option }
 (** A source location and what is at this location *)
 
+let location ?msg a = { range = OffsetRange a; description = msg }
 let location_loc ?msg a = { range = OffsetRange a; description = msg }
 let location_lexing ?msg a = { range = Token a; description = msg }
 let location_position ?msg a = { range = Position a; description = msg }
@@ -42,6 +43,7 @@ let location_position ?msg a = { range = Position a; description = msg }
 type error_class =
   | Unhandled  (** Programmer error *)
   | InputError  (** input error *)
+  | TypeError  (** type error *)
   | Error  (** input error *)
   | Exception of exn  (** Programmer error *)
   | VerifierAlarm  (** Verification error *)
@@ -51,6 +53,7 @@ let show_error_class = function
   | Exception exn -> "exception " ^ Printexc.to_string exn
   | VerifierAlarm -> "verification failure"
   | InputError -> "input error"
+  | TypeError -> "type error"
   | Error -> "error"
 
 type extra_loc_info =
@@ -60,6 +63,9 @@ type extra_loc_info =
       input : Pp_loc.Input.t;  (** input *)
       locations : location list;  (** locations to print *)
     }  (** contextual information *)
+    (* TODO: print these *)
+  | InputFile of location_info list  (** A related location in the input file *)
+  | ContextString of string  (** Any random dumped debug messgae *)
 
 type error_info = {
   relevant_input_locations : location_info list;  (** Char offset ranges *)
@@ -202,9 +208,12 @@ let format_extra_location_info fmt = function
       let pos = Position (p, p) in
       Format.fprintf fmt "%s:%d:%d%a%a" p.pos_fname p.pos_lnum p.pos_cnum
         Format.newline () (format_location input) [ pos ]
-  | OtherFile { name; input; locations } ->
-      Format.fprintf fmt "%s%a%a" name Format.pp_print_newline ()
-        (format_location input) locations
+  | OtherFile { name; input; locations } -> (
+      try
+        Format.fprintf fmt "%s%a%a" name Format.pp_print_newline ()
+          (format_location input) locations
+      with Sys_error _ ->
+        Format.fprintf fmt "\"%s\" (error: no such file)" name)
 
 let pp_bincamlerr fmt { messages; input } =
   let format_message fmt
@@ -232,9 +241,11 @@ let pp_bincamlerr fmt { messages; input } =
   let fmt_msgs = Format.list ~sep:Format.newline format_message in
   Format.fprintf fmt "%a" fmt_msgs (List.rev messages)
 
-let regprinter () =
+let () =
   Printexc.register_printer (function
     | BincamlError info -> Some (Format.asprintf "%a" pp_bincamlerr info)
     | _ -> None)
 
-let () = regprinter ()
+let to_result f =
+  try Ok (f ())
+  with BincamlError e -> Error (Format.asprintf "%a" pp_bincamlerr e)

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -1,0 +1,162 @@
+open Containers
+(** Error printing *)
+
+(** {2 Error Types} *)
+
+type loc = int * int
+(** A text token range; (beginchar, endchar) *)
+
+type location = OffsetRange of loc | Token of Lexing.lexbuf
+
+let show_location = function
+  | OffsetRange (a, b) -> Printf.sprintf "char range (%d, %d)" a b
+  | Token lexbuf ->
+      let a, b = (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf) in
+      Printf.sprintf "%s: from %d:%d to %d:%d" a.pos_fname a.pos_lnum a.pos_cnum
+        b.pos_lnum b.pos_cnum
+
+let loc_to_position = function
+  | OffsetRange (begin_tok, end_tok) ->
+      (Pp_loc.Position.of_offset begin_tok, Pp_loc.Position.of_offset end_tok)
+  | Token lexbuf ->
+      ( Pp_loc.Position.of_lexing @@ Lexing.lexeme_start_p lexbuf,
+        Pp_loc.Position.of_lexing @@ Lexing.lexeme_end_p lexbuf )
+
+type location_info = { range : location; description : string option }
+(** A source location and what is at this location *)
+
+type error_class =
+  | Unhandled  (** Programmer error *)
+  | Exception of exn  (** Programmer error *)
+  | VerifierAlarm  (** Verification error *)
+
+let show_error_class = function
+  | Unhandled -> "programmer_error"
+  | Exception exn -> "exception " ^ Printexc.to_string exn
+  | VerifierAlarm -> "verification failure"
+
+type error_info = {
+  relevant_input_locations : location_info list;  (** Char offset ranges *)
+  relevant_source_code_locations : Lexing.position list;
+      (** bincaml source code location, if relevant *)
+  message : string;  (** context message *)
+  reason : error_class;  (** type or error *)
+}
+
+type error_context = {
+  input : Pp_loc.Input.t option;
+  messages : error_info list;
+}
+
+(** {2 Annotating error information} *)
+
+(** Add source file to error context *)
+let add_source_info ?input c =
+  match input with Some _ -> { c with input } | _ -> c
+
+let error_message ?here ?input_location message (reason : error_class) =
+  {
+    relevant_input_locations = Option.to_list input_location;
+    relevant_source_code_locations = Option.to_list here;
+    message;
+    reason;
+  }
+
+let push_message err_info msg =
+  { err_info with messages = msg :: err_info.messages }
+
+let update_message ?here ?input_location ?input_file info =
+  let top, messages =
+    info.messages |> function
+    | m :: t -> (m, t)
+    | [] -> (error_message "error" Unhandled, [])
+  in
+  let n =
+    {
+      top with
+      relevant_input_locations =
+        Option.to_list input_location @ top.relevant_input_locations;
+      relevant_source_code_locations =
+        Option.to_list here @ top.relevant_source_code_locations;
+    }
+  in
+  let info = add_source_info ?input:input_file info in
+  { info with messages = n :: messages }
+
+exception BincamlError of error_context
+
+let raise_error ?here ?input_location message (reason : error_class) =
+  let e = error_message ?here ?input_location message reason in
+  raise (BincamlError { input = None; messages = [ e ] })
+
+(** Run a function but add error information to an exception it throws *)
+let protect_with_info mod_info f =
+  try f ()
+  with BincamlError info ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace (BincamlError (mod_info info)) bt
+
+(** Run a function but add error information to any exception it throws *)
+let protect ?here ?input_location ?input_file f =
+  try f () with
+  | BincamlError info ->
+      let bt = Printexc.get_raw_backtrace () in
+      let new_err = update_message ?here ?input_location ?input_file info in
+      Printexc.raise_with_backtrace (BincamlError new_err) bt
+  | other ->
+      let m =
+        error_message ?here ?input_location "exception" (Exception other)
+      in
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace
+        (BincamlError { input = input_file; messages = [ m ] })
+        bt
+
+(** {3 printer}*)
+
+let format_ploc input =
+ fun f ->
+  Pp_loc.setup_highlight_tags f
+    ~single_line_underline:
+      {
+        open_tag =
+          (fun _ -> Format.ANSI_codes.string_of_style_list [ `Bold; `FG `Red ]);
+        close_tag = (fun _ -> Format.ANSI_codes.string_of_style `Reset);
+      }
+    ();
+
+  Pp_loc.pp ~input ~max_lines:5 f
+
+let format_location_info ?input fmt { range; description } =
+  let description = Option.get_or ~default:"" description in
+  match input with
+  | None -> Format.fprintf fmt "%s at " description
+  | Some input ->
+      Format.fprintf fmt "%s%a%a" description Format.pp_print_newline ()
+        (format_ploc input)
+        [ loc_to_position range ]
+
+let pp_bincamlerr fmt { messages; input } =
+  let format_message fmt
+      {
+        message;
+        reason;
+        relevant_input_locations;
+        relevant_source_code_locations;
+      } =
+    let fmt_locations =
+      Format.list ~sep:Format.newline (format_location_info ?input)
+    in
+    let message =
+      Format.fprintf fmt "%s : %s%a%a" message (show_error_class reason)
+        Format.newline () fmt_locations relevant_input_locations
+    in
+    message
+  in
+  let fmt_msgs = Format.list ~sep:Format.newline format_message in
+  Format.fprintf fmt "%a" fmt_msgs messages
+
+let () =
+  Printexc.register_printer (function
+    | BincamlError info -> Some (Format.asprintf "%a" pp_bincamlerr info)
+    | _ -> None)

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -6,7 +6,11 @@ open Containers
 type loc = int * int
 (** A text token range; (beginchar, endchar) *)
 
-type location = OffsetRange of loc | Token of Lexing.lexbuf
+type location =
+  | OffsetRange of loc
+  | Token of Lexing.lexbuf
+  | Position of (Lexing.position * Lexing.position)
+  | PPPosition of (Pp_loc.Position.t * Pp_loc.Position.t)
 
 let show_location = function
   | OffsetRange (a, b) -> Printf.sprintf "char range (%d, %d)" a b
@@ -14,6 +18,10 @@ let show_location = function
       let a, b = (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf) in
       Printf.sprintf "%s: from %d:%d to %d:%d" a.pos_fname a.pos_lnum a.pos_cnum
         b.pos_lnum b.pos_cnum
+  | Position (a, b) ->
+      Printf.sprintf "%s: from %d:%d to %d:%d" a.pos_fname a.pos_lnum a.pos_cnum
+        b.pos_lnum b.pos_cnum
+  | PPPosition (a, b) -> "position"
 
 let loc_to_position = function
   | OffsetRange (begin_tok, end_tok) ->
@@ -21,12 +29,20 @@ let loc_to_position = function
   | Token lexbuf ->
       ( Pp_loc.Position.of_lexing @@ Lexing.lexeme_start_p lexbuf,
         Pp_loc.Position.of_lexing @@ Lexing.lexeme_end_p lexbuf )
+  | Position (b, e) -> (Pp_loc.Position.of_lexing b, Pp_loc.Position.of_lexing e)
+  | PPPosition (a, b) -> (a, b)
 
 type location_info = { range : location; description : string option }
 (** A source location and what is at this location *)
 
+let location_loc ?msg a = { range = OffsetRange a; description = msg }
+let location_lexing ?msg a = { range = Token a; description = msg }
+let location_position ?msg a = { range = Position a; description = msg }
+
 type error_class =
   | Unhandled  (** Programmer error *)
+  | InputError  (** input error *)
+  | Error  (** input error *)
   | Exception of exn  (** Programmer error *)
   | VerifierAlarm  (** Verification error *)
 
@@ -34,10 +50,20 @@ let show_error_class = function
   | Unhandled -> "programmer_error"
   | Exception exn -> "exception " ^ Printexc.to_string exn
   | VerifierAlarm -> "verification failure"
+  | InputError -> "input error"
+  | Error -> "error"
+
+type extra_loc_info =
+  | Sourcecode of Lexing.position  (** input file *)
+  | OtherFile of {
+      name : string;  (** informative name *)
+      input : Pp_loc.Input.t;  (** input *)
+      locations : location list;  (** locations to print *)
+    }  (** contextual information *)
 
 type error_info = {
   relevant_input_locations : location_info list;  (** Char offset ranges *)
-  relevant_source_code_locations : Lexing.position list;
+  relevant_source_code_locations : extra_loc_info list;
       (** bincaml source code location, if relevant *)
   message : string;  (** context message *)
   reason : error_class;  (** type or error *)
@@ -51,8 +77,17 @@ type error_context = {
 (** {2 Annotating error information} *)
 
 (** Add source file to error context *)
-let add_source_info ?input c =
-  match input with Some _ -> { c with input } | _ -> c
+let add_input ?input ?input_file ?input_channel c =
+  let input =
+    Option.or_ c.input
+      ~else_:
+        (Option.or_ input
+           ~else_:
+             (Option.or_
+                (Option.map Pp_loc.Input.file input_file)
+                ~else_:(Option.map Pp_loc.Input.in_channel input_channel)))
+  in
+  { c with input }
 
 let error_message ?here ?input_location message (reason : error_class) =
   {
@@ -62,10 +97,10 @@ let error_message ?here ?input_location message (reason : error_class) =
     reason;
   }
 
-let push_message err_info msg =
+let push_message msg err_info =
   { err_info with messages = msg :: err_info.messages }
 
-let update_message ?here ?input_location ?input_file info =
+let update_message ?here ?input_location ?input info =
   let top, messages =
     info.messages |> function
     | m :: t -> (m, t)
@@ -80,10 +115,24 @@ let update_message ?here ?input_location ?input_file info =
         Option.to_list here @ top.relevant_source_code_locations;
     }
   in
-  let info = add_source_info ?input:input_file info in
+  let info = add_input ?input info in
   { info with messages = n :: messages }
 
 exception BincamlError of error_context
+
+let error ?here ?input_location ?input ?input_file ?input_channel message
+    (reason : error_class) =
+  let e = error_message ?here ?input_location message reason in
+  let e =
+    { input = None; messages = [ e ] }
+    |> add_input ?input ?input_file ?input_channel
+  in
+  e
+
+let reraise_error ?here ?input_location message (reason : error_class) =
+  let bt = Printexc.get_raw_backtrace () in
+  let e = error_message ?here ?input_location message reason in
+  raise (BincamlError { input = None; messages = [ e ] }) bt
 
 let raise_error ?here ?input_location message (reason : error_class) =
   let e = error_message ?here ?input_location message reason in
@@ -92,30 +141,42 @@ let raise_error ?here ?input_location message (reason : error_class) =
 (** Run a function but add error information to an exception it throws *)
 let protect_with_info mod_info f =
   try f ()
-  with BincamlError info ->
+  with err -> (
     let bt = Printexc.get_raw_backtrace () in
-    Printexc.raise_with_backtrace (BincamlError (mod_info info)) bt
+    match mod_info err with
+    | Some e -> Printexc.raise_with_backtrace (BincamlError e) bt
+    | None -> Printexc.raise_with_backtrace err bt)
 
-(** Run a function but add error information to any exception it throws *)
-let protect ?here ?input_location ?input_file f =
-  try f () with
+let error_of_exn ?here ?input_location ?input = function
   | BincamlError info ->
-      let bt = Printexc.get_raw_backtrace () in
-      let new_err = update_message ?here ?input_location ?input_file info in
-      Printexc.raise_with_backtrace (BincamlError new_err) bt
+      let new_err = update_message ?here ?input_location ?input info in
+      new_err
   | other ->
       let m =
         error_message ?here ?input_location "exception" (Exception other)
       in
-      let bt = Printexc.get_raw_backtrace () in
-      Printexc.raise_with_backtrace
-        (BincamlError { input = input_file; messages = [ m ] })
-        bt
+      { input; messages = [ m ] }
+
+(** Run a function but add error information to any exception it throws *)
+let wrap_error ?here ?input_location ?input f =
+  try f ()
+  with e ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace
+      (BincamlError (error_of_exn ?here ?input_location ?input e))
+      bt
+
+(** Run a function but add error information to any exception it throws *)
+let update_error info f =
+  try f ()
+  with BincamlError ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace (BincamlError (info ex)) bt
 
 (** {3 printer}*)
 
-let format_ploc input =
- fun f ->
+let format_location input =
+ fun f l ->
   Pp_loc.setup_highlight_tags f
     ~single_line_underline:
       {
@@ -125,7 +186,7 @@ let format_ploc input =
       }
     ();
 
-  Pp_loc.pp ~input ~max_lines:5 f
+  Pp_loc.pp ~input ~max_lines:5 f (List.map loc_to_position l)
 
 let format_location_info ?input fmt { range; description } =
   let description = Option.get_or ~default:"" description in
@@ -133,8 +194,17 @@ let format_location_info ?input fmt { range; description } =
   | None -> Format.fprintf fmt "%s at " description
   | Some input ->
       Format.fprintf fmt "%s%a%a" description Format.pp_print_newline ()
-        (format_ploc input)
-        [ loc_to_position range ]
+        (format_location input) [ range ]
+
+let format_extra_location_info fmt = function
+  | Sourcecode p ->
+      let input = Pp_loc.Input.file p.pos_fname in
+      let pos = Position (p, p) in
+      Format.fprintf fmt "%s:%d:%d%a%a" p.pos_fname p.pos_lnum p.pos_cnum
+        Format.newline () (format_location input) [ pos ]
+  | OtherFile { name; input; locations } ->
+      Format.fprintf fmt "%s%a%a" name Format.pp_print_newline ()
+        (format_location input) locations
 
 let pp_bincamlerr fmt { messages; input } =
   let format_message fmt
@@ -147,16 +217,24 @@ let pp_bincamlerr fmt { messages; input } =
     let fmt_locations =
       Format.list ~sep:Format.newline (format_location_info ?input)
     in
-    let message =
-      Format.fprintf fmt "%s : %s%a%a" message (show_error_class reason)
-        Format.newline () fmt_locations relevant_input_locations
+    let fmt_extra_locations =
+      Format.list ~sep:Format.newline format_extra_location_info
     in
-    message
+    Format.fprintf fmt "%s: %s%a%a" (show_error_class reason) message
+      Format.newline () fmt_locations relevant_input_locations;
+    Format.pp_force_newline fmt ();
+    if List.is_empty relevant_source_code_locations |> not then begin
+      Format.fprintf fmt "Related locations:";
+      Format.pp_force_newline fmt ();
+      Format.fprintf fmt "%a" fmt_extra_locations relevant_source_code_locations
+    end
   in
   let fmt_msgs = Format.list ~sep:Format.newline format_message in
-  Format.fprintf fmt "%a" fmt_msgs messages
+  Format.fprintf fmt "%a" fmt_msgs (List.rev messages)
 
-let () =
+let regprinter () =
   Printexc.register_printer (function
     | BincamlError info -> Some (Format.asprintf "%a" pp_bincamlerr info)
     | _ -> None)
+
+let () = regprinter ()

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -6,78 +6,102 @@ open Containers
 type loc = int * int
 (** A text token range; (beginchar, endchar) *)
 
+(** Information about some location in text or file *)
 type location =
-  | OffsetRange of loc
-  | Token of Lexing.lexbuf
-  | Position of (Lexing.position * Lexing.position)
+  | OffsetRange of loc  (** Character offset range *)
+  | Lexbuf of Lexing.lexbuf
+      (** Lexbuf mid-parsing (use last token as position) *)
+  | Lexing of (Lexing.position * Lexing.position option)
   | PPPosition of (Pp_loc.Position.t * Pp_loc.Position.t)
+      (** PP_loc position range *)
+  | Everything  (** whole file *)
 
+(** Pretty-print a location numerically, without a known input file *)
 let show_location = function
   | OffsetRange (a, b) -> Printf.sprintf "char range (%d, %d)" a b
-  | Token lexbuf ->
+  | Lexbuf lexbuf ->
       let a, b = (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf) in
       Printf.sprintf "%s: from %d:%d to %d:%d" a.pos_fname a.pos_lnum a.pos_cnum
         b.pos_lnum b.pos_cnum
-  | Position (a, b) ->
-      Printf.sprintf "%s: from %d:%d to %d:%d" a.pos_fname a.pos_lnum a.pos_cnum
-        b.pos_lnum b.pos_cnum
-  | PPPosition (a, b) -> "position"
+  | Lexing (a, b) ->
+      let b =
+        match b with
+        | Some b -> Printf.sprintf " to %d:%d" b.pos_lnum b.pos_cnum
+        | _ -> ""
+      in
+      Printf.sprintf "%s: from %d:%d%s" a.pos_fname a.pos_lnum a.pos_cnum b
+  | PPPosition (a, b) -> "PPPosition ?" (* cannot convert back *)
+  | Everything -> "file"
 
 let loc_to_position = function
   | OffsetRange (begin_tok, end_tok) ->
-      (Pp_loc.Position.of_offset begin_tok, Pp_loc.Position.of_offset end_tok)
-  | Token lexbuf ->
-      ( Pp_loc.Position.of_lexing @@ Lexing.lexeme_start_p lexbuf,
-        Pp_loc.Position.of_lexing @@ Lexing.lexeme_end_p lexbuf )
-  | Position (b, e) -> (Pp_loc.Position.of_lexing b, Pp_loc.Position.of_lexing e)
-  | PPPosition (a, b) -> (a, b)
+      Some
+        (Pp_loc.Position.of_offset begin_tok, Pp_loc.Position.of_offset end_tok)
+  | Lexbuf lexbuf ->
+      Some
+        ( Pp_loc.Position.of_lexing @@ Lexing.lexeme_start_p lexbuf,
+          Pp_loc.Position.of_lexing @@ Lexing.lexeme_end_p lexbuf )
+  | Lexing (b, Some e) ->
+      Some (Pp_loc.Position.of_lexing b, Pp_loc.Position.of_lexing e)
+  | PPPosition (a, b) -> Some (a, b)
+  | _ -> None
 
-type location_info = { range : location; description : string option }
+type ref_file =
+  | Input of Pp_loc.Input.t
+  | SourceFile  (** The input file *)
+  | RawString of string  (** just string content *)
+
+type error_context_info = {
+  description : string option;  (** What is this object? Why is it relevant? *)
+  loc : location;  (** Location in relevant 'file'. *)
+  input : ref_file;  (** 'file' we are referring to. *)
+}
 (** A source location and what is at this location *)
 
-let location ?msg a = { range = OffsetRange a; description = msg }
-let location_loc ?msg a = { range = OffsetRange a; description = msg }
-let location_lexing ?msg a = { range = Token a; description = msg }
-let location_position ?msg a = { range = Position a; description = msg }
+let location ?msg a =
+  { loc = OffsetRange a; description = msg; input = SourceFile }
+
+let location_loc ?msg ?(input = SourceFile) a =
+  { loc = OffsetRange a; description = msg; input }
+
+let location_lexing ?msg ?(input = SourceFile) a =
+  { loc = Lexbuf a; description = msg; input }
+
+let location_position ?msg ?(input = SourceFile) a =
+  { loc = Lexing a; description = msg; input }
+
+let location_pp_position ?msg ?(input = SourceFile) a =
+  { loc = PPPosition a; description = msg; input }
+
+let context_callsite msg (loc : Lexing.position) =
+  let input = Input (Pp_loc.Input.file loc.pos_fname) in
+  { description = Some msg; input; loc = Lexing (loc, None) }
+
+let context_message ?msg content =
+  { loc = Everything; description = msg; input = RawString content }
 
 type error_class =
-  | Unhandled  (** Programmer error *)
-  | InputError  (** input error *)
-  | TypeError  (** type error *)
-  | Error  (** input error *)
-  | Exception of exn  (** Programmer error *)
+  | Unhandled  (** Undefined output for some case *)
+  | InputError  (** Input program malformed *)
+  | TypeError  (** Type error *)
+  | Error  (** Programmer error *)
+  | Exception of exn  (** Programmer error; wrapper for other exceptions *)
   | VerifierAlarm  (** Verification error *)
 
 let show_error_class = function
-  | Unhandled -> "programmer_error"
-  | Exception exn -> "exception " ^ Printexc.to_string exn
-  | VerifierAlarm -> "verification failure"
-  | InputError -> "input error"
-  | TypeError -> "type error"
-  | Error -> "error"
-
-type extra_loc_info =
-  | Sourcecode of Lexing.position  (** input file *)
-  | OtherFile of {
-      name : string;  (** informative name *)
-      input : Pp_loc.Input.t;  (** input *)
-      locations : location list;  (** locations to print *)
-    }  (** contextual information *)
-    (* TODO: print these *)
-  | InputFile of location_info list  (** A related location in the input file *)
-  | ContextString of string  (** Any random dumped debug messgae *)
+  | Unhandled -> "Programmer error"
+  | Exception exn -> "Exception " ^ Printexc.to_string exn
+  | VerifierAlarm -> "Verification failure"
+  | InputError -> "Input error"
+  | TypeError -> "Type error"
+  | Error -> "Error"
 
 type error_info = {
-  relevant_input_locations : location_info list;  (** Char offset ranges *)
-  relevant_source_code_locations : extra_loc_info list;
-      (** bincaml source code location, if relevant *)
-  message : string;  (** context message *)
-  reason : error_class;  (** type or error *)
-}
-
-type error_context = {
+  message : string;  (** Error message *)
+  reason : error_class;  (** Type of error *)
   input : Pp_loc.Input.t option;
-  messages : error_info list;
+      (** Input corresponding to [SourceFile] (the bincaml il) *)
+  error_context : error_context_info list;  (** List of context information *)
 }
 
 (** {2 Annotating error information} *)
@@ -95,54 +119,42 @@ let add_input ?input ?input_file ?input_channel c =
   in
   { c with input }
 
-let error_message ?here ?input_location message (reason : error_class) =
-  {
-    relevant_input_locations = Option.to_list input_location;
-    relevant_source_code_locations = Option.to_list here;
-    message;
-    reason;
-  }
-
-let push_message msg err_info =
-  { err_info with messages = msg :: err_info.messages }
-
-let update_message ?here ?input_location ?input info =
-  let top, messages =
-    info.messages |> function
-    | m :: t -> (m, t)
-    | [] -> (error_message "error" Unhandled, [])
+let error_message ?here ?input ?ctx_info message (reason : error_class) =
+  let here =
+    Option.map (context_callsite "Bincaml source") here |> Option.to_list
   in
+  { error_context = here @ Option.to_list ctx_info; input; message; reason }
+
+let add_error_context ?ctx_info ?input info =
   let n =
-    {
-      top with
-      relevant_input_locations =
-        Option.to_list input_location @ top.relevant_input_locations;
-      relevant_source_code_locations =
-        Option.to_list here @ top.relevant_source_code_locations;
-    }
+    { info with error_context = Option.to_list ctx_info @ info.error_context }
   in
-  let info = add_input ?input info in
-  { info with messages = n :: messages }
+  let info = add_input ?input n in
+  info
 
-exception BincamlError of error_context
+exception BincamlError of error_info
 
-let error ?here ?input_location ?input ?input_file ?input_channel message
+let error ?here ?ctx_info ?input ?input_file ?input_channel message
     (reason : error_class) =
-  let e = error_message ?here ?input_location message reason in
-  let e =
-    { input = None; messages = [ e ] }
-    |> add_input ?input ?input_file ?input_channel
-  in
-  e
+  error_message ?here ?ctx_info message reason
+  |> add_input ?input ?input_file ?input_channel
 
-let reraise_error ?here ?input_location message (reason : error_class) =
+let reraise_error ?here ?ctx_info message (reason : error_class) =
   let bt = Printexc.get_raw_backtrace () in
-  let e = error_message ?here ?input_location message reason in
-  raise (BincamlError { input = None; messages = [ e ] }) bt
+  let e =
+    error_message ?here ?ctx_info message reason
+    |> add_error_context
+         ?ctx_info:(Option.map (context_callsite "rethrown from") here)
+  in
+  Printexc.raise_with_backtrace (BincamlError e) bt
 
-let raise_error ?here ?input_location message (reason : error_class) =
-  let e = error_message ?here ?input_location message reason in
-  raise (BincamlError { input = None; messages = [ e ] })
+let raise_error ?here ?ctx_info message (reason : error_class) =
+  let e =
+    error_message ?ctx_info message reason
+    |> add_error_context
+         ?ctx_info:(Option.map (context_callsite "thrown from") here)
+  in
+  raise (BincamlError e)
 
 (** Run a function but add error information to an exception it throws *)
 let protect_with_info mod_info f =
@@ -153,23 +165,21 @@ let protect_with_info mod_info f =
     | Some e -> Printexc.raise_with_backtrace (BincamlError e) bt
     | None -> Printexc.raise_with_backtrace err bt)
 
-let error_of_exn ?here ?input_location ?input = function
+let error_of_exn ?ctx_info ?input = function
   | BincamlError info ->
-      let new_err = update_message ?here ?input_location ?input info in
+      let new_err = add_error_context ?ctx_info ?input info in
       new_err
   | other ->
-      let m =
-        error_message ?here ?input_location "exception" (Exception other)
-      in
-      { input; messages = [ m ] }
+      let m = error_message ?ctx_info "exception" (Exception other) in
+      m
 
 (** Run a function but add error information to any exception it throws *)
-let wrap_error ?here ?input_location ?input f =
+let wrap_error ?here ?ctx_info ?input f =
   try f ()
   with e ->
     let bt = Printexc.get_raw_backtrace () in
     Printexc.raise_with_backtrace
-      (BincamlError (error_of_exn ?here ?input_location ?input e))
+      (BincamlError (error_of_exn ?ctx_info ?input e))
       bt
 
 (** Run a function but add error information to any exception it throws *)
@@ -178,6 +188,9 @@ let update_error info f =
   with BincamlError ex ->
     let bt = Printexc.get_raw_backtrace () in
     Printexc.raise_with_backtrace (BincamlError (info ex)) bt
+
+let update_ctx ?ctx_info ?input f =
+  update_error (add_error_context ?ctx_info ?input) f
 
 (** {3 printer}*)
 
@@ -192,16 +205,22 @@ let format_location input =
       }
     ();
 
-  Pp_loc.pp ~input ~max_lines:5 f (List.map loc_to_position l)
+  let ps = List.filter_map loc_to_position l in
+  if not @@ List.is_empty ps then Pp_loc.pp ~input ~max_lines:5 f ps
+  else
+    Format.list ~sep:Format.newline
+      (fun f a -> Format.fprintf f "%s" @@ show_location a)
+      f l
 
-let format_location_info ?input fmt { range; description } =
+let format_context_info ?source fmt { loc; input; description; _ } =
   let description = Option.get_or ~default:"" description in
-  match input with
-  | None -> Format.fprintf fmt "%s at " description
-  | Some input ->
+  match (input, source) with
+  | Input input, _ | SourceFile, Some input ->
       Format.fprintf fmt "%s%a%a" description Format.pp_print_newline ()
-        (format_location input) [ range ]
+        (format_location input) [ loc ]
+  | _ -> Format.fprintf fmt "%s at " description
 
+(*
 let format_extra_location_info fmt = function
   | Sourcecode p ->
       let input = Pp_loc.Input.file p.pos_fname in
@@ -213,33 +232,20 @@ let format_extra_location_info fmt = function
         Format.fprintf fmt "%s%a%a" name Format.pp_print_newline ()
           (format_location input) locations
       with Sys_error _ ->
-        Format.fprintf fmt "\"%s\" (error: no such file)" name)
+        Format.fprintf fmt "\"%s\" (error: no such file)" name) *)
 
-let pp_bincamlerr fmt { messages; input } =
-  let format_message fmt
-      {
-        message;
-        reason;
-        relevant_input_locations;
-        relevant_source_code_locations;
-      } =
-    let fmt_locations =
-      Format.list ~sep:Format.newline (format_location_info ?input)
-    in
-    let fmt_extra_locations =
-      Format.list ~sep:Format.newline format_extra_location_info
-    in
-    Format.fprintf fmt "%s: %s%a%a" (show_error_class reason) message
-      Format.newline () fmt_locations relevant_input_locations;
-    Format.pp_force_newline fmt ();
-    if List.is_empty relevant_source_code_locations |> not then begin
-      Format.fprintf fmt "Related locations:";
-      Format.pp_force_newline fmt ();
-      Format.fprintf fmt "%a" fmt_extra_locations relevant_source_code_locations
-    end
+let pp_bincamlerr fmt { message; reason; error_context; input } =
+  let fmt_locations =
+    Format.list ~sep:Format.newline (format_context_info ?source:input)
   in
-  let fmt_msgs = Format.list ~sep:Format.newline format_message in
-  Format.fprintf fmt "%a" fmt_msgs (List.rev messages)
+  Format.fprintf fmt "%s: %s%a" (show_error_class reason) message Format.newline
+    ();
+  Format.pp_force_newline fmt ();
+  if List.is_empty error_context |> not then begin
+    Format.fprintf fmt "Related context:";
+    Format.pp_force_newline fmt ();
+    Format.fprintf fmt "%a" fmt_locations error_context
+  end
 
 let () =
   Printexc.register_printer (function

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -189,9 +189,6 @@ let update_error info f =
     let bt = Printexc.get_raw_backtrace () in
     Printexc.raise_with_backtrace (BincamlError (info ex)) bt
 
-let update_ctx ?ctx_info ?input f =
-  update_error (add_error_context ?ctx_info ?input) f
-
 (** {3 printer}*)
 
 let format_location input =

--- a/test/cram/logs.t
+++ b/test/cram/logs.t
@@ -29,6 +29,7 @@ Some error messages for log configuration.
 
   $ cat << EOF | bincaml script -
   > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level debug)
   > (log-level)
   > (run-transforms "irreducible-loops")
   > EOF

--- a/test/cram/logs.t
+++ b/test/cram/logs.t
@@ -34,8 +34,10 @@ Some error messages for log configuration.
   > (run-transforms "irreducible-loops")
   > EOF
   (load-il ../../examples/irreducible_loop_1.il)
+  (log-level debug)
   (log-level)
-  bincaml: log-level: Expected at least one argument
+  bincaml: Error: Expected at least one argument in cmd log-level
+           
            
   [123]
 
@@ -46,7 +48,8 @@ Some error messages for log configuration.
   > EOF
   (load-il ../../examples/irreducible_loop_1.il)
   (log-level blah)
-  bincaml: log-level: Incorrect log level option given, correct options are ["info", "quiet", "app", "error", "warning", "debug"]
+  bincaml: Error: Incorrect log level option given, correct options are ["info", "quiet", "app", "error", "warning", "debug"] in cmd log-level
+           
            
   [123]
 
@@ -58,6 +61,7 @@ Some error messages for log configuration.
   > EOF
   (load-il ../../examples/irreducible_loop_1.il)
   (log-level info nowheoijifsda)
-  bincaml: log-level: source nowheoijifsda not found
+  bincaml: Error: source nowheoijifsda not found in cmd log-level
+           
            
   [123]

--- a/test/cram/typepass.t
+++ b/test/cram/typepass.t
@@ -1,9 +1,13 @@
   $ bincaml script ./typepass.sexp
   (load-il ../../examples/cat.il)
   (run-transforms type-check)
-  (load-il ../../examples/cntlm-output.il)
-  (run-transforms type-check)
-  (load-il ../../examples/irreducible_loop_1.il)
-  (run-transforms type-check)
-  (load-il ../../examples/cntlm-simp-output.il)
-  (run-transforms type-check)
+  bincaml: Exception Failure("Check failed: @main_4197696"): exception
+           
+           Related context:
+           ./typepass.sexp
+           2 | (run-transforms "type-check")
+                                          ^
+           
+  Paramters for the function has a type mismatch: type of bvadd(0x1:bv24, 0x4:bv64) != type of $_PC:bv64 (bv24 != bv64) at statement 9 in %main_entry
+  bv64 is not a bitvector type in bvadd at statement 9 in %main_entry
+  [123]

--- a/test/cram/typepass.t
+++ b/test/cram/typepass.t
@@ -1,13 +1,9 @@
   $ bincaml script ./typepass.sexp
   (load-il ../../examples/cat.il)
   (run-transforms type-check)
-  bincaml: Exception Failure("Check failed: @main_4197696"): exception
-           
-           Related context:
-           ./typepass.sexp
-           2 | (run-transforms "type-check")
-                                          ^
-           
-  Paramters for the function has a type mismatch: type of bvadd(0x1:bv24, 0x4:bv64) != type of $_PC:bv64 (bv24 != bv64) at statement 9 in %main_entry
-  bv64 is not a bitvector type in bvadd at statement 9 in %main_entry
-  [123]
+  (load-il ../../examples/cntlm-output.il)
+  (run-transforms type-check)
+  (load-il ../../examples/irreducible_loop_1.il)
+  (run-transforms type-check)
+  (load-il ../../examples/cntlm-simp-output.il)
+  (run-transforms type-check)

--- a/test/hmtype/initial.t
+++ b/test/hmtype/initial.t
@@ -2,5 +2,11 @@
 
   $ bincaml load-il error_assert_type.il
   (run-transforms hindley-milner-elaborate)
-  bincaml: Lang__Hm__Hm_types.TypeErr("type_error: bool <> 32 \226\132\149 bv assert 0x1:bv32")
+  bincaml: Type error: type_error: bool <> 32 ℕ bv
+           
+           Related context:
+           statement
+           9 |     assert (1:bv32);
+                          ^^^^^^^^
+           
   [123]

--- a/test/lang/test_hm_inline.ml
+++ b/test/lang/test_hm_inline.ml
@@ -21,5 +21,7 @@ let%expect_test "return type of function" =
     uncurry ret type: bv64
 
     partially apply bv64: ok((bv64->bv64))
-    type error: error(type_error: 64 <> 24)
+    type error: error(Type error: type_error: 64 <> 24
+
+    )
     |}]


### PR DESCRIPTION
I wanted better error messages when debugging type errors...

General idea is there is one representation of error, and some functions to help wrap and rethrow the error with additional info, e.g. the input file we care about. This means the context does not have to be passed all the way down to where the error is created, however its probably is not very adaptable to the logging / debug. In general this should preserve ocamls' backtraces but you have to be careful not to throw in any of the error-annotation functions.

- [x] Location attributes on exprs
- [ ] Location attributes could just directly store the originating file: this pr currently can't do anything if we load and concatenate multiple files at once :(
- [x] Move the location annotations all to the extra_information list attached to an error message; its all just context with the "input file" being a special case. 
- [x] tests
- [x] make the output cleaner
- [ ] when you modify the top of the error message stack; how do you know your information is relevant to the error there? Do you need some conditional behaviour? Its theoretically possible with the current api but not amazing.

IR still missing some information for these things:

<img width="1042" height="418" alt="image" src="https://github.com/user-attachments/assets/a6547b85-6a6e-47a3-8425-0a924c767b59" />

Open to suggestions on naming for the functions in `Errors`, lots of things called `protect` and it doesn't really make sense but I don't have a good idea atm what to name them.

Reading guide: start at the section `(** {2 Annotating error information} *)` in `errors.ml`
