### PR TITLE
Expect test globs

### DIFF
--- a/bin/runfile.ml
+++ b/bin/runfile.ml
@@ -12,7 +12,6 @@ let run_il_prog fnames =
   let attr =
     Program.attrib p |> StringMap.find_opt ".run" |> Option.map Attrib.to_sexp
   in
-  (*
   let a () =
     Option.map Containers.Sexp.to_string attr |> Option.get_or ~default:""
   in
@@ -22,7 +21,7 @@ let run_il_prog fnames =
          (Errors.context_message
             ~msg:("prog script in " ^ String.concat "," fnames)
             (a ())))
-     @@ fun () ->
-    Script.protect_with_input st @@ fun () ->*)
+  @@ fun () ->
+  Script.protect_with_input st @@ fun () ->
   Option.map (fun attr -> Script.of_cmd st (`List [ `Atom "progn"; attr ])) attr
   |> Option.get_or ~default:st

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -1688,7 +1688,8 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   ( "Input error: load error\
    \n\
    \nRelated context:\
@@ -1715,7 +1716,8 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   ( "Input error: load error\
    \n\
    \nRelated context:\

--- a/lib/loadir.ml
+++ b/lib/loadir.ml
@@ -1688,12 +1688,11 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
+[@@expect.uncaught_exn {|
   ( "Input error: load error\
    \n\
    \nRelated context:\
-   \nno such block: %main_7 at ")
+   \nno such block: %main_7 in <?.il>")
   |}]
 
 let%expect_test "missing proc" =
@@ -1716,12 +1715,11 @@ proc @main_4196260 () -> ()
   in
   ignore @@ disable_backtrace_in run;
   [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
+[@@expect.uncaught_exn {|
   ( "Input error: load error\
    \n\
    \nRelated context:\
-   \nno such procedure: @cat_4198032 at ")
+   \nno such procedure: @cat_4198032 in <?.il>")
   |}]
 
 let%expect_test "syntax error" =

--- a/lib/util/errors.ml
+++ b/lib/util/errors.ml
@@ -215,7 +215,8 @@ let format_context_info ?source fmt { loc; input; description; _ } =
   | Input input, _ | SourceFile, Some input ->
       Format.fprintf fmt "%s%a%a" description Format.pp_print_newline ()
         (format_location input) [ loc ]
-  | _ -> Format.fprintf fmt "%s at " description
+  | RawString s, _ -> Format.fprintf fmt "%s: %s" description s
+  | SourceFile, None -> Format.fprintf fmt "%s in <?.il>" description
 
 (*
 let format_extra_location_info fmt = function
@@ -241,7 +242,7 @@ let pp_bincamlerr fmt { message; reason; error_context; input } =
   if List.is_empty error_context |> not then begin
     Format.fprintf fmt "Related context:";
     Format.pp_force_newline fmt ();
-    Format.fprintf fmt "%a" fmt_locations error_context
+    Format.fprintf fmt "%a" fmt_locations (List.rev error_context)
   end
 
 let () =

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,13 @@
  (modules test_bincaml)
  (libraries bincaml_inline_tests))
 
+(executable
+ (package bincaml)
+ (public_name gen_expect)
+ (modules gen_expect)
+ (name gen_expect)
+ (libraries containers))
+
 (library
  (name bincaml_inline_tests)
  (inline_tests)

--- a/test/gen_expect.ml
+++ b/test/gen_expect.ml
@@ -1,0 +1,53 @@
+open Containers
+
+let preamble =
+  {|
+(rule
+ (alias runtest)
+ (package %PACKAGE%)
+ (deps %DEPS% %INPUT%)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to %OUT% (run %ACTION%)))
+    (diff? %EXPECT% %OUT%)
+)))
+
+|}
+
+let usage_msg = "util_expect -action \"bincaml load-ir ARG\" <file1> [<file2>]"
+let input_files = ref []
+let action = ref ""
+let package = ref "bincaml"
+let deps = ref "%{bin:bincaml}"
+let anon_fun filename = input_files := filename :: !input_files
+
+let to_rule fname =
+  let expected = fname ^ ".expected" in
+  let output = fname ^ ".out" in
+  let action = String.replace ~which:`All ~by:fname ~sub:"ARG" !action in
+  print_endline "";
+  preamble
+  |> String.replace ~which:`All ~by:fname ~sub:"%INPUT%"
+  |> String.replace ~which:`All ~by:!deps ~sub:"%DEPS%"
+  |> String.replace ~which:`All ~by:expected ~sub:"%EXPECT%"
+  |> String.replace ~which:`All ~by:output ~sub:"%OUT%"
+  |> String.replace ~which:`All ~by:action ~sub:"%ACTION%"
+  |> String.replace ~which:`All ~by:!package ~sub:"%PACKAGE%"
+  |> print_endline
+
+let speclist =
+  [
+    ("-action", Arg.Set_string action, "Set output file name");
+    ("-package", Arg.Set_string package, "Set package");
+    ("-deps", Arg.Set_string package, "Set extra deps");
+  ]
+  |> Arg.align
+
+let () =
+  let () = Arg.parse speclist anon_fun usage_msg in
+  if String.equal !action "" then begin
+    Arg.usage speclist "gen_expect error: -action must be provided.";
+    exit 1
+  end;
+  List.iter to_rule !input_files

--- a/test/hmtype/decl_use_hint_disagree.il
+++ b/test/hmtype/decl_use_hint_disagree.il
@@ -2,10 +2,13 @@ prog entry @main {
     .run = ["progn"; ["run-transforms"; "hindley-milner-elaborate"] ]
 };
 
+var $g : bv32;
+var $h : bv64;
+
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    $h:bv64 := bvadd(1:bv64, $g:bv64);
     return;
   ];
 ];

--- a/test/hmtype/decl_use_hint_disagree.il.expected
+++ b/test/hmtype/decl_use_hint_disagree.il.expected
@@ -1,0 +1,10 @@
+(run-transforms hindley-milner-elaborate)
+bincaml: Type error: type_error: 32 <> 64
+         
+         Related context:
+         infer expr: bvadd(0x1:bv64, $g)
+         statement
+         11 |     $h:bv64 := bvadd(1:bv64, $g:bv64);
+                  [1;31m^^[0m
+         
+         prog script in ./decl_use_hint_disagree.il: (progn (run-transforms hindley-milner-elaborate))

--- a/test/hmtype/dune
+++ b/test/hmtype/dune
@@ -8,6 +8,7 @@
 (include dune.inc)
 
 (rule
+ (package bincaml)
  (deps
   %{bin:gen_expect}
   (glob_files *.il))
@@ -24,6 +25,7 @@
     "bincaml"))))
 
 (rule
+ (package bincaml)
  (alias runtest)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/test/hmtype/dune
+++ b/test/hmtype/dune
@@ -4,3 +4,26 @@
   %{bin:bincaml}
   (glob_files *.il)
   (glob_files *.sexp)))
+
+(include dune.inc)
+
+(rule
+ (deps
+  %{bin:gen_expect}
+  (glob_files *.il))
+ (action
+  (with-stdout-to
+   dune.inc.gen
+   (run
+    %{deps}
+    -action
+    "bincaml load-il ARG"
+    -deps
+    "%{bin:bincaml}"
+    -package
+    "bincaml"))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/hmtype/dune.inc
+++ b/test/hmtype/dune.inc
@@ -17,20 +17,6 @@
 (rule
  (alias runtest)
  (package bincaml)
- (deps %{bin:bincaml} ./error_inside_expr.il)
- (action
-    (progn
-    (with-accepted-exit-codes (or 0 (not 0))
-    (with-outputs-to ./error_inside_expr.il.out (run bincaml load-il ./error_inside_expr.il)))
-    (diff? ./error_inside_expr.il.expected ./error_inside_expr.il.out)
-)))
-
-
-
-
-(rule
- (alias runtest)
- (package bincaml)
  (deps %{bin:bincaml} ./error_hint_global.il)
  (action
     (progn

--- a/test/hmtype/dune.inc
+++ b/test/hmtype/dune.inc
@@ -1,0 +1,112 @@
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_use_global.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_use_global.il.out (run bincaml load-il ./error_use_global.il)))
+    (diff? ./error_use_global.il.expected ./error_use_global.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_inside_expr.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_inside_expr.il.out (run bincaml load-il ./error_inside_expr.il)))
+    (diff? ./error_inside_expr.il.expected ./error_inside_expr.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_hint_global.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_hint_global.il.out (run bincaml load-il ./error_hint_global.il)))
+    (diff? ./error_hint_global.il.expected ./error_hint_global.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_declaration_disagreement.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_declaration_disagreement.il.out (run bincaml load-il ./error_declaration_disagreement.il)))
+    (diff? ./error_declaration_disagreement.il.expected ./error_declaration_disagreement.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_assign_local.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_assign_local.il.out (run bincaml load-il ./error_assign_local.il)))
+    (diff? ./error_assign_local.il.expected ./error_assign_local.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_assign_global.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_assign_global.il.out (run bincaml load-il ./error_assign_global.il)))
+    (diff? ./error_assign_global.il.expected ./error_assign_global.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./error_assert_type.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./error_assert_type.il.out (run bincaml load-il ./error_assert_type.il)))
+    (diff? ./error_assert_type.il.expected ./error_assert_type.il.out)
+)))
+
+
+
+
+(rule
+ (alias runtest)
+ (package bincaml)
+ (deps %{bin:bincaml} ./decl_use_hint_disagree.il)
+ (action
+    (progn
+    (with-accepted-exit-codes (or 0 (not 0))
+    (with-outputs-to ./decl_use_hint_disagree.il.out (run bincaml load-il ./decl_use_hint_disagree.il)))
+    (diff? ./decl_use_hint_disagree.il.expected ./decl_use_hint_disagree.il.out)
+)))
+
+

--- a/test/hmtype/error_assert_type.il.expected
+++ b/test/hmtype/error_assert_type.il.expected
@@ -1,0 +1,9 @@
+(run-transforms hindley-milner-elaborate)
+bincaml: Type error: type_error: bool <> 32 ℕ bv
+         
+         Related context:
+         statement
+         8 |     assert (1:bv32);
+                        [1;31m^^^^^^^^[0m
+         
+         prog script in ./error_assert_type.il: (progn (run-transforms hindley-milner-elaborate))

--- a/test/hmtype/error_assign_global.il
+++ b/test/hmtype/error_assign_global.il
@@ -2,10 +2,12 @@ prog entry @main {
     .run = ["progn"; ["run-transforms"; "hindley-milner-elaborate"] ]
 };
 
+var $g : bv64;
+
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    var $g:bv64 := (1:bv32);
     return;
   ];
 ];

--- a/test/hmtype/error_assign_global.il.expected
+++ b/test/hmtype/error_assign_global.il.expected
@@ -1,0 +1,8 @@
+bincaml: Input error: parse error
+         
+         Related context:
+         next token
+         10 |     var $g:bv64 := (1:bv32);
+                      [1;31m^^[0m
+         
+         command: load-il (./error_assign_global.il)

--- a/test/hmtype/error_assign_local.il
+++ b/test/hmtype/error_assign_local.il
@@ -5,7 +5,7 @@ prog entry @main {
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    var l:bv64 := (1:bv32);
     return;
   ];
 ];

--- a/test/hmtype/error_assign_local.il.expected
+++ b/test/hmtype/error_assign_local.il.expected
@@ -1,0 +1,9 @@
+(run-transforms hindley-milner-elaborate)
+bincaml: Type error: type_error: 64 <> 32
+         
+         Related context:
+         statement
+         8 |     var l:bv64 := (1:bv32);
+                     [1;31m^^^^^^^^^^^^^^^^^^[0m
+         
+         prog script in ./error_assign_local.il: (progn (run-transforms hindley-milner-elaborate))

--- a/test/hmtype/error_declaration_disagreement.il
+++ b/test/hmtype/error_declaration_disagreement.il
@@ -1,11 +1,14 @@
+
 prog entry @main {
     .run = ["progn"; ["run-transforms"; "hindley-milner-elaborate"] ]
 };
 
+var $g : bv32;
+
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    $g:bv64 := bvadd(1:bv64, $g:bv64);
     return;
   ];
 ];

--- a/test/hmtype/error_declaration_disagreement.il.expected
+++ b/test/hmtype/error_declaration_disagreement.il.expected
@@ -1,0 +1,10 @@
+(run-transforms hindley-milner-elaborate)
+bincaml: Type error: type_error: 32 <> 64
+         
+         Related context:
+         infer expr: bvadd(0x1:bv64, $g)
+         statement
+         11 |     $g:bv64 := bvadd(1:bv64, $g:bv64);
+                  [1;31m^^[0m
+         
+         prog script in ./error_declaration_disagreement.il: (progn (run-transforms hindley-milner-elaborate))

--- a/test/hmtype/error_hint_global.il
+++ b/test/hmtype/error_hint_global.il
@@ -1,11 +1,14 @@
+
 prog entry @main {
     .run = ["progn"; ["run-transforms"; "hindley-milner-elaborate"] ]
 };
 
+var $g : bv25;
+
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    var $g:bv64 := (1:bv32);
     return;
   ];
 ];

--- a/test/hmtype/error_hint_global.il.expected
+++ b/test/hmtype/error_hint_global.il.expected
@@ -1,0 +1,8 @@
+bincaml: Input error: parse error
+         
+         Related context:
+         next token
+         11 |     var $g:bv64 := (1:bv32);
+                      [1;31m^^[0m
+         
+         command: load-il (./error_hint_global.il)

--- a/test/hmtype/error_use_global.il
+++ b/test/hmtype/error_use_global.il
@@ -2,10 +2,12 @@ prog entry @main {
     .run = ["progn"; ["run-transforms"; "hindley-milner-elaborate"] ]
 };
 
+var $g : bv25;
+
 proc @main () -> ()
 [
   block %main_entry [
-    assert (1:bv32);
+    $g:bv32 := bvadd(1:bv64, $g);
     return;
   ];
 ];

--- a/test/hmtype/error_use_global.il.expected
+++ b/test/hmtype/error_use_global.il.expected
@@ -1,0 +1,10 @@
+(run-transforms hindley-milner-elaborate)
+bincaml: Type error: type_error: 25 <> 64
+         
+         Related context:
+         infer expr: bvadd(0x1:bv64, $g)
+         statement
+         10 |     $g:bv32 := bvadd(1:bv64, $g);
+                  [1;31m^^[0m
+         
+         prog script in ./error_use_global.il: (progn (run-transforms hindley-milner-elaborate))

--- a/test/hmtype/initial.t
+++ b/test/hmtype/initial.t
@@ -6,7 +6,8 @@
            
            Related context:
            statement
-           9 |     assert (1:bv32);
+           8 |     assert (1:bv32);
                           ^^^^^^^^
            
+           prog script in error_assert_type.il: (progn (run-transforms hindley-milner-elaborate))
   [123]


### PR DESCRIPTION
Expect style tests like boogie et. al use using just dune. Add an il file to `test/hmtype` and it will create an expected file for the output. This intended for error info.

Some small type system tests included.

Maybe it would make sense to have a whole directory next to cram for this sort of tests and restrict to the extension `.il.t` or something so we don't have to repeat the annoying dune setup for it.